### PR TITLE
Only fixup naming references to the project. Leave the filenames.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# videojs-ads
+# videojs-contrib-ads
 
-The `videojs-ads` plugin provides common functionality needed by video advertisement libraries working with [video.js.](http://www.videojs.com/)
+The `videojs-contrib-ads` plugin provides common functionality needed by video advertisement libraries working with [video.js.](http://www.videojs.com/)
 It takes care of a number of concerns for you, reducing the code you have to write for your ad integration.
 
 ## Getting Started

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "videojs-ads",
+  "name": "videojs-contrib-ads",
   "version": "0.1.0",
   "author": {
     "name": "Brightcove"


### PR DESCRIPTION
This commit fixes just the project references to the old 'videojs-ads' name but leaves the actual files untouched per comment on https://github.com/videojs/videojs-contrib-ads/pull/14.
