### PR TITLE
Fixing a bug with removing the poster image

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -239,7 +239,7 @@ var
   removeNativePoster = function(player) {
     var tech = player.el().querySelector('.vjs-tech');
     if (tech) {
-      tech.poster = null;
+      tech.removeAttribute('poster');
     }
   },
 


### PR DESCRIPTION
Maybe it's related to [this change](https://github.com/videojs/video.js/pull/1062), but setting "tech.poster" to null doesn't work in VideoJS versions 4.4.2 and 4.4.3. However, using "removeAttribute" seems to work fine. Great job, internet.
