### PR TITLE
Make contentupdate's lastSrc public

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -467,13 +467,13 @@ var
       'adend',    // endLinearAdMode()
     ]), fsmHandler);
     
+    // keep track of last src
     // lastSrc should be editable to allow changing resolutions without triggering an ad
     player.ads.lastSrc = undefined;
     
     // implement 'contentupdate' event.
     (function(){
       var
-        // keep track of last src
         // check if a new src has been set, if so, trigger contentupdate
         checkSrc = function() {
           var src;


### PR DESCRIPTION
Add public variable `player.ads.lastSrc` to allow other plugins to change the source without triggering a `contentupdate` and an ad.
