### PR TITLE
increase selector specificity

### DIFF
--- a/src/videojs.ads.css
+++ b/src/videojs.ads.css
@@ -3,14 +3,14 @@
  */
 
 /* Ad playback */
-.vjs-ad-playing .vjs-progress-control {
+.vjs-ad-playing.vjs-ad-playing .vjs-progress-control {
   pointer-events: none;
 }
-.vjs-ad-playing .vjs-play-progress {
+.vjs-ad-playing.vjs-ad-playing .vjs-play-progress {
   background-color: #ffe400;
 }
 
 /* Ad loading */
-.vjs-ad-loading .vjs-loading-spinner {
+.vjs-ad-playing.vjs-ad-loading .vjs-loading-spinner {
   display: block;
 }


### PR DESCRIPTION
Increase the selector specificity for the play, progress, and loading controls.
This is because if you have a selector that was slightly more specific which modified these, we would no longer see these changes.
