### PR TITLE
Allow override of resume behavior for burned-in ads.

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -220,7 +220,11 @@ var
     // with a custom ad display or burned-in ads, the content player state
     // hasn't been modified and so no restoration is required
     if (player.currentSrc() === snapshot.src) {
-      player.play();
+      //this will always be true unless specifically overriden in the
+      //client implementation.  For instance, when playing a post-roll.
+      if (snapshot.play) {
+        player.play();
+      }
       return;
     }
 

--- a/test/videojs.ads.test.js
+++ b/test/videojs.ads.test.js
@@ -293,6 +293,35 @@ test('changing src does not trigger contentupdate during ad playback', function(
   
 });
 
+test('snapshot on resume without src change checks play property', function() {
+  var playCalled = 0;
+  player.on('play', function(){
+    playCalled++;
+  });
+  // enter ad playback mode
+  player.trigger('adsready');
+  player.trigger('play');
+  player.trigger('adstart');
+  
+  // set src and trigger synthetic 'loadstart'
+  player.src('http://media.w3.org/2010/05/sintel/trailer.mp4');
+  player.trigger('loadstart');
+  
+  // finish playing ad
+  player.trigger('adend');
+  
+  // confirm one play event is triggered
+  equal(playCalled, 1, 'one play event should have been triggered');
+  
+  playCalled = 0;
+  player.trigger('adstart');
+  player.ads.snapshot.play = false;
+  player.trigger('adend');
+
+  // confirm no play events are triggered
+  equal(playCalled, 0, 'no play events should have been triggered');
+});
+
 
 test('the cancel-play timeout is cleared when exiting "preroll?"', function() {
   var callbacks = [];


### PR DESCRIPTION
Some clients do not want to resume playback when using burned-in ads.  This change allows users to specify the resume behavior when using burned-in ads.  Implementors can now set 

``` javascript
player.ads.snapshot.play = false
```

while the ad is playing to prevent playback from resuming.
