### PR TITLE
Fixes poster flashing in between prerolls and content playing.

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -256,9 +256,19 @@ var
    * @param {object} player The videojs player object
    */
   removeNativePoster = function(player) {
-    var tech = player.el().querySelector('.vjs-tech');
+    var
+      poster = player.el().querySelector('.vjs-poster'),
+      bigplaybutton = player.el().querySelector('.vjs-big-play-button'),
+      tech = player.el().querySelector('.vjs-tech');
+
     if (tech) {
       tech.removeAttribute('poster');
+    }
+    if (poster) {
+      poster.style.display = 'none';
+    }
+    if (bigplaybutton) {
+      bigplaybutton.style.display = 'none';
     }
   },
 


### PR DESCRIPTION
Set display to none on the poster and play button elements while preroll handshake is in progress.