### PR TITLE
Prevent a simulated play event from being triggered when there is no src...

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -528,9 +528,13 @@ var
       setImmediate(checkSrc);
     })();
 
-    // kick off the fsm
-    if (!player.paused()) {
+    // The player.currentSrc() check here is necessary
+    // because the flash tech incorrectly returns "false" when
+    // there is no src set and player.paused() is called.
+    // https://github.com/videojs/video-js-swf/issues/136
+    if (!player.paused() && player.currentSrc()) {
       // simulate a play event if we're autoplaying
+      // and kick off the fsm
       fsmHandler({type:'play'});
     }
 


### PR DESCRIPTION
... set and the flash tech is in use.