### PR TITLE
player.remoteTextTracks -> player.textTracks

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -140,7 +140,7 @@ var
   getPlayerSnapshot = function(player) {
     var
       tech = player.el().querySelector('.vjs-tech'),
-      tracks = player.remoteTextTracks(),
+      tracks = player.textTracks(),
       track,
       i,
       suppressedTracks = [],

--- a/test/videojs.ads.snapshot.js
+++ b/test/videojs.ads.snapshot.js
@@ -400,7 +400,7 @@ test('checks for a src attribute change that isn\'t reflected in currentSrc', fu
 });
 
 test('When captions are enabled, the video\'s tracks will be disabled during the ad', function() {
-  var tracks = player.remoteTextTracks(),
+  var tracks = player.textTracks(),
       showing = 0,
       disabled = 0,
       i;


### PR DESCRIPTION
Plugin was throwing an error looking for player.remoteTextTracks method. I was unable to locate the method in the videojs library, but upon searching through old commits on this file it looks like the method is a remnant that wasn't corrected.

If I am wrong, I'd like to know where to find the method remoteTextTracks on the player object.