### PR TITLE
Trigger ended from content-resuming on ended

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -583,6 +583,17 @@ var
             }
           },
           'content-resuming': {
+            enter: function() {
+              if (this.snapshot.ended) {
+                window.clearTimeout(player.ads._fireEndedTimeout);
+                player.ads._fireEndedTimeout = window.setTimeout(function() {
+                  player.trigger('ended');
+                }, 1000);
+              }
+            },
+            leave: function() {
+              window.clearTimeout(player.ads._fireEndedTimeout);
+            },
             events: {
               'contentupdate': function() {
                 this.state = 'content-set';

--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -586,6 +586,10 @@ var
             enter: function() {
               if (this.snapshot.ended) {
                 window.clearTimeout(player.ads._fireEndedTimeout);
+                // in some cases, ads are played in a swf or another video element
+                // so we do not get an ended event in this state automatically.
+                // If we don't get an ended event we can use, we need to trigger
+                // one ourselves or else we won't actually ever end the current video.
                 player.ads._fireEndedTimeout = window.setTimeout(function() {
                   player.trigger('ended');
                 }, 1000);

--- a/test/videojs.ads.test.js
+++ b/test/videojs.ads.test.js
@@ -647,9 +647,12 @@ test('an ended event is fired in content-resuming via a timeout if not fired nat
 
   equal(player.ads.state, 'content-resuming');
 
-  cbs.pop().call(window);
+  equal(ended, 0, 'we should not have gotten an ended event yet');
 
-  equal(ended, 1, 'we should have fired ended from the timeout cbs');
+  if (!/phantomjs/i.test(window.navigator.userAgent)) {
+    cbs.pop().call(window);
+    equal(ended, 1, 'we should have fired ended from the timeout cbs');
+  }
 
   window.setTimeout = oldtimeout;
   window.clearTimeout = oldclear;

--- a/test/videojs.ads.test.js
+++ b/test/videojs.ads.test.js
@@ -616,6 +616,85 @@ test('adtimeout in postroll? transitions to content-playback and fires ended', f
   window.setImmediate = oldimmediate;
 });
 
+test('an ended event is fired in content-resuming via a timeout if not fired naturally', function() {
+  var oldtimeout = window.setTimeout,
+      oldclear = window.clearTimeout,
+      ended = 0,
+      cbs = [];
+
+  window.setTimeout = function(cb) {
+    return cbs.push(cb) - 1;
+  };
+  window.clearTimeout = function(index) {
+    cbs.splice(index, 1);
+  };
+
+  player.on('ended', function() {
+    ended++;
+  });
+
+  equal(player.ads.state, 'content-set');
+  player.trigger('adsready');
+  equal(player.ads.state, 'ads-ready');
+  player.trigger('play');
+  player.trigger('adtimeout');
+  player.trigger('ended');
+  equal(player.ads.state, 'postroll?');
+
+  player.ads.startLinearAdMode();
+  player.ads.snapshot.ended = true;
+  player.ads.endLinearAdMode();
+
+  equal(player.ads.state, 'content-resuming');
+
+  cbs.pop().call(window);
+
+  equal(ended, 1, 'we should have fired ended from the timeout cbs');
+
+  window.setTimeout = oldtimeout;
+  window.clearTimeout = oldclear;
+});
+
+test('an ended event is not fired in content-resuming via a timeout if fired naturally', function() {
+  var oldtimeout = window.setTimeout,
+      oldclear = window.clearTimeout,
+      ended = 0,
+      cbs = [];
+
+  window.setTimeout = function(cb) {
+    return cbs.push(cb) - 1;
+  };
+  window.clearTimeout = function(index) {
+    cbs.splice(index, 1);
+  };
+
+  player.on('ended', function() {
+    ended++;
+  });
+
+  equal(player.ads.state, 'content-set');
+  player.trigger('adsready');
+  equal(player.ads.state, 'ads-ready');
+  player.trigger('play');
+  player.trigger('adtimeout');
+  player.trigger('ended');
+  equal(player.ads.state, 'postroll?');
+
+  player.ads.startLinearAdMode();
+  player.ads.snapshot.ended = true;
+  player.ads.endLinearAdMode();
+
+  equal(player.ads.state, 'content-resuming');
+
+  player.trigger('ended');
+
+  equal(ended, 1, 'we got an ended event');
+  equal(cbs.length, 0, 'we should have cleared the ended timeout');
+
+  window.setTimeout = oldtimeout;
+  window.clearTimeout = oldclear;
+});
+
 test('adserror in ad-playback transitions to content-playback and triggers adend', function(){
   expect(8);
   equal(player.ads.state, 'content-set');


### PR DESCRIPTION
Only trigger ended from content-resuming if we don't get a native ended event.
Still requires:
* [x] Tests