### PR TITLE
Don't stop propagation on video element events.

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -5,7 +5,7 @@
   <title>Example Ad Integration</title>
   <!-- Load local video.js -->
   <link rel="stylesheet" href="../node_modules/video.js/dist/video-js/video-js.min.css">
-  <script src="../node_modules/video.js/dist/video-js/video.js"></script>
+  <script src="../node_modules/video.js/dist/video-js/video.dev.js"></script>
   <!-- Load local ads plugin. -->
   <link rel="stylesheet" href="../src/videojs.ads.css">
   <script src="../src/videojs.ads.js"></script>

--- a/test/ads.html
+++ b/test/ads.html
@@ -5,7 +5,7 @@
   <title>ads Test Suite</title>
   <!-- Load local video.js -->
   <link rel="stylesheet" href="../node_modules/video.js/dist/video-js/video-js.min.css" media="screen">
-  <script src="../node_modules/video.js/dist/video-js/video.js"></script>
+  <script src="../node_modules/video.js/dist/video-js/video.dev.js"></script>
   <!-- Load local QUnit. -->
   <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css" media="screen">
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>


### PR DESCRIPTION
Previously, event.stopImmediatePropagation was used on redispatched
events but that was causing issues because the actual native events were
getting stopped in addition to the player events. Updated to stop
immediate propagation manually so only the player events will stop.
The changes to stopImmediatePropagation mean that this cannot be used
with the google closure compiled version of videojs.

Also, tryToResume now checks the video element's readyState for trying
to resume. Fixes #46. Android devices in particular fail to have a
seekable property after reloading a video, especially, with HLS
content.