### PR TITLE
add commonjs enablers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,9 @@
     "grunt-contrib-qunit": "~0.2.0",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.4.0",
-    "qunitjs": "^1.17.1",
-    "video.js": "git+ssh://git@github.com:streamrail/video.js.git"
+    "qunitjs": "^1.17.1"
   },
   "dependencies": {
-    "video.js": "^4.12.5"
+    "video.js": "git+ssh://git@github.com:streamrail/video.js.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.4.0",
     "qunitjs": "^1.17.1",
-    "video.js": "^4.12.4"
+    "video.js": "git+ssh://git@github.com:streamrail/video.js.git"
   },
   "dependencies": {
     "video.js": "^4.12.5"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
     "prepublish": "grunt"
   },
   "devDependencies": {
+    "guid": "git+ssh://git@github.com:streamrail/guid.git",
+    "createjs": "git+ssh://git@github.com:streamrail/createjs-browserify.git",
+    "q": "^1.2.0",
+    "jquery": "^2.1.3",
+    "eventemitter3": "^0.1.6",
+    "inherits": "^2.0.1",
+    "rusha": "^0.8.2",
     "es5-shim": "^4.1.0",
     "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.4.0",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,6 @@
     "prepublish": "grunt"
   },
   "devDependencies": {
-    "guid": "git+ssh://git@github.com:streamrail/guid.git",
-    "createjs": "git+ssh://git@github.com:streamrail/createjs-browserify.git",
-    "q": "^1.2.0",
-    "jquery": "^2.1.3",
-    "eventemitter3": "^0.1.6",
-    "inherits": "^2.0.1",
-    "rusha": "^0.8.2",
     "es5-shim": "^4.1.0",
     "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.4.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "https://github.com/videojs/videojs-contrib-ads.git"
   },
+  "main": "src/videojs.ads.js",
   "version": "2.0.0",
   "author": {
     "name": "Brightcove"
@@ -28,5 +29,8 @@
     "grunt-contrib-watch": "~0.4.0",
     "qunitjs": "^1.17.1",
     "video.js": "^4.12.4"
+  },
+  "dependencies": {
+    "video.js": "^4.12.5"
   }
 }

--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -1,13 +1,3 @@
-(function(factory){
-    "use strict";
-    if (typeof define === 'function' && define.amd) {
-        define('videojs-contrib-ads', ['videojs'], function(vjs){factory(window, document, vjs);});
-    } else if (typeof exports === 'object' && typeof module === 'object') {
-        factory(window, document, require('video.js'));
-    } else {
-        factory(window, document, videojs);
-    }
-})
 /**
  * Basic Ad support plugin for video.js.
  *
@@ -788,4 +778,4 @@ var
   // register the ad plugin framework
   vjs.plugin('ads', adFramework);
 
-});
+})(window, document, window.videojs);


### PR DESCRIPTION
The package is suited to be required as a commonjs module, except that some settings are missing from the package.json file to make this possible. I've added these changes, and was then able to successfully consume it as a commonjs module ("require('videojs-contrib-ads');" from my code).  

Feel free to merge if you find it useful, I guess it would benefit people working with this commonjs style. 