### PR TITLE
Adstart adend checks

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -460,11 +460,15 @@ var
       state: 'content-set',
 
       startLinearAdMode: function() {
-        player.trigger('adstart');
+        if (player.ads.state !== 'ad-playback') {
+          player.trigger('adstart');
+        }
       },
 
       endLinearAdMode: function() {
-        player.trigger('adend');
+        if (player.ads.state === 'ad-playback') {
+          player.trigger('adend');
+        }
       }
     };
 
@@ -523,7 +527,6 @@ var
               },
               'adstart': function() {
                 this.state = 'ad-playback';
-                player.el().className += ' vjs-ad-playing';
               },
               'adtimeout': function() {
                 this.state = 'content-playback';
@@ -567,8 +570,12 @@ var
               // capture current player state snapshot (playing, currentTime, src)
               this.snapshot = getPlayerSnapshot(player);
 
-              // remove the poster so it doesn't flash between videos
+              // add css to the element to indicate and ad is playing.
+              player.el().className += ' vjs-ad-playing';
+
+              // remove the poster so it doesn't flash between ads
               removeNativePoster(player);
+
               // We no longer need to supress play events once an ad is playing.
               // Clear it if we were.
               if (player.ads.cancelPlayTimeout) {
@@ -578,11 +585,10 @@ var
             },
             leave: function() {
               removeClass(player.el(), 'vjs-ad-playing');
-
               restorePlayerSnapshot(player, this.snapshot);
+              // trigger 'adend' as a consistent notification
+              // event that we're exiting ad-playback.
               if (player.ads.triggerevent !== 'adend') {
-                // trigger 'adend' as a consistent notification
-                // event that we're exiting ad-playback.
                 player.trigger('adend');
               }
             },
@@ -640,7 +646,6 @@ var
             events: {
               'adstart': function() {
                 this.state = 'ad-playback';
-                player.el().className += ' vjs-ad-playing';
               },
               'adtimeout': function() {
                 this.state = 'content-resuming';
@@ -677,9 +682,6 @@ var
               },
               'adstart': function() {
                 this.state = 'ad-playback';
-                player.el().className += ' vjs-ad-playing';
-                // remove the poster so it doesn't flash between videos
-                removeNativePoster(player);
               },
               'contentupdate': function() {
                 if (player.paused()) {


### PR DESCRIPTION
Use the ad-playback state to make adstart and adend trigger more accurately. Remove duplicate code around triggering adstart state that is already included in the ad-playback.enter().