### PR TITLE
Update current content video to be sourced from `snapshot.source` ins…

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -151,10 +151,10 @@ var
       i,
       suppressedTracks = [],
       snapshot = {
-        ended: player.ended(),
-        src: player.currentSrc(),
         currentTime: player.currentTime(),
-        type: player.currentType()
+        ended: player.ended(),
+        source: player.currentSource(),
+        src: player.currentSrc()
       };
 
     if (tech) {
@@ -313,7 +313,7 @@ var
       player.one('contentloadedmetadata', restoreTracks);
 
       // if the src changed for ad playback, reset it
-      player.src({ src: snapshot.src, type: snapshot.type });
+      player.src(snapshot.source);
       // safari requires a call to `load` to pick up a changed source
       player.load();
       // and then resume from the snapshots time once the original src has loaded

--- a/test/videojs.ads.snapshot.js
+++ b/test/videojs.ads.snapshot.js
@@ -422,11 +422,14 @@ test('changing the source and then timing out does not restore a snapshot', func
 // should check for src attribute modifications as well
 test('checks for a src attribute change that isn\'t reflected in currentSrc', function() {
   var updatedSrc;
+  player.currentSource = function() {
+    return {
+      src: 'content.mp4',
+      type: 'video/mp4'
+    };
+  };
   player.currentSrc = function() {
     return 'content.mp4';
-  };
-  player.currentType = function() {
-    return 'video/mp4';
   };
 
   player.trigger('adsready');


### PR DESCRIPTION
…tead of `snapshot.src` and `snapshot.type`.

Remove `snapshot.type` since it's unnecessary. I also suppose there was an existing issue where the `type` did not exist, but I am guessing that it was a silent error.

This will no longer be a problem as the current content video will be initialized with the exact same data that it was original configured with.

Minor formatting.