### PR TITLE
add rule to hide vjs-tech when ad loading

### DIFF
--- a/src/videojs.ads.css
+++ b/src/videojs.ads.css
@@ -14,3 +14,9 @@
 .vjs-ad-playing.vjs-ad-loading .vjs-loading-spinner {
   display: block;
 }
+
+/* Hide vjs-tech when ad loading to prevent content flash */
+.vjs-ima3-flash.vjs-ad-loading .vjs-tech,
+.vjs-ima3-flash.vjs-ad-loading .vjs-poster { 
+    opacity:0; 
+}


### PR DESCRIPTION
When using autplay and pre-roll ads, content in vjs-tech flashes before the preroll ad begins. Adding CSS rules to hide vjs-tech when .vjs-ima3-flash.vjs-ad-loading