### PR TITLE
Add adsfallback event to fallback on another source

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -27,6 +27,7 @@
       // events emitted by third party ad implementors
       'adsready',
       'adscanceled',
+      'adsfallback',
       'adstart',  // startLinearAdMode()
       'adend'     // endLinearAdMode()
 

--- a/example/example-integration-fallback.js
+++ b/example/example-integration-fallback.js
@@ -1,0 +1,151 @@
+/**
+ * Example ad integration using the videojs-ads plugin.
+ *
+ * For each content video, this plugin plays one preroll and one midroll.
+ * Ad content is chosen randomly from the URLs listed in inventory.json.
+ */
+(function(window, document, vjs, undefined) {
+"use strict";
+
+  /**
+   * Register the ad integration plugin.
+   * To initialize for a player, call player.exampleAds().
+   *
+   * @param {mixed} options Hash of obtions for the exampleAds plugin.
+   */
+  vjs.plugin('exampleAds', function(options){
+
+    var
+
+      player = this,
+
+      // example plugin state, may have any of these properties:
+      //  - inventory - hypothetical ad inventory, list of URLs to ads
+      //  - lastTime - the last time observed during content playback
+      //  - adPlaying - whether a linear ad is currently playing
+      //  - prerollPlayed - whether we've played a preroll
+      //  - midrollPlayed - whether we've played a midroll
+      //  - postrollPlayed - whether we've played a postroll
+      state = {},
+
+      // just like any other video.js plugin, ad integrations can
+      // accept initialization options
+      adServerUrl = (options && options.adServerUrl) || "inventory-fallback.json",
+      midrollPoint = (options && options.midrollPoint) || 15,
+
+      // asynchronous method for requesting ad inventory
+      requestAds = function() {
+
+        // reset plugin state
+        state = {};
+
+        // fetch ad inventory
+        // the 'src' parameter is ignored by the example inventory.json flat file,
+        // but this shows how you might send player information along to the ad server.
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", adServerUrl + "?src=" + encodeURIComponent(player.currentSrc()));
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState === 4) {
+            try {
+              state.inventory = JSON.parse(xhr.responseText);
+              player.trigger('adsready');
+            } catch (err) {
+              throw new Error('Couldn\'t parse inventory response as JSON');
+            }
+          }
+        };
+        xhr.send(null);
+
+      },
+
+      // play an ad, given an opportunity
+      playAd = function() {
+
+        // short-circuit if we don't have any ad inventory to play
+        if (!state.inventory || state.inventory.length === 0) {
+          return;
+        }
+
+        // tell ads plugin we're ready to play our ad
+        player.ads.startLinearAdMode();
+        state.adPlaying = true;
+
+        // tell videojs to load the ad
+        var media = state.inventory[Math.floor(Math.random() * state.inventory.length)];
+        player.src(media);
+
+        // when it's finished
+        player.one('adended', function() {
+          // play your linear ad content, then when it's finished ...
+          player.ads.endLinearAdMode();
+          state.adPlaying = false;
+        });
+
+      };
+
+    player.on('error', function() {
+      player.trigger('adsfallback');
+    });
+
+    // initialize the ads plugin, passing in any relevant options
+    player.ads(options);
+
+    // request ad inventory whenever the player gets new content to play
+    player.on('contentupdate', requestAds);
+    // if there's already content loaded, request an add immediately
+    if (player.currentSrc()) {
+      requestAds();
+    }
+
+    player.on('contentended', function() {
+      if (!state.postrollPlayed && player.ads.state === 'postroll?') {
+        state.postrollPlayed = true;
+        playAd();
+      }
+    });
+
+    // play an ad the first time there's a preroll opportunity
+    player.on('readyforpreroll', function() {
+      if (!state.prerollPlayed) {
+        state.prerollPlayed = true;
+        playAd();
+      }
+    });
+
+    player.on('adstart', function() {
+      player.on('adsfallback', function() {
+        requestAds();
+      });
+    });
+
+    player.on('adend', function() {
+      player.off('adsfallback', function() {
+        requestAds();
+      });
+    });
+
+    // watch for time to pass 15 seconds, then play an ad
+    // if we haven't played a midroll already
+    player.on('timeupdate', function(event) {
+
+      if (state.midrollPlayed) {
+        return;
+      }
+
+      var currentTime = player.currentTime(), opportunity;
+
+      if ('lastTime' in state) {
+        opportunity = currentTime > midrollPoint && state.lastTime < midrollPoint;
+      }
+
+      state.lastTime = currentTime;
+      if (opportunity) {
+        state.midrollPlayed = true;
+        playAd();
+      }
+
+    });
+
+  });
+
+})(window, document, videojs);

--- a/example/fallback.html
+++ b/example/fallback.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Example Ad Integration</title>
+  <!-- Load local video.js -->
+  <link rel="stylesheet" href="../node_modules/video.js/dist/video-js/video-js.min.css">
+  <script src="../node_modules/video.js/dist/video-js/video.dev.js"></script>
+  <!-- Load local ads plugin. -->
+  <link rel="stylesheet" href="../src/videojs.ads.css">
+  <script src="../src/videojs.ads.js"></script>
+  <!-- Load example ads integraiton. -->
+  <script src="example-integration-fallback.js"></script>
+  <link rel="stylesheet" href="app.css">
+</head>
+<body>
+
+  <h1>Example Ad Integration</h1>
+
+  <video
+    id="examplePlayer"
+    class="video-js vjs-default-skin"
+    width="640"
+    height="264"
+    poster="http://video-js.zencoder.com/oceans-clip.png"
+    autoplay
+    controls>
+    <source src="http://video-js.zencoder.com/oceans-clip.mp4" type='video/mp4' />
+    <source src="http://video-js.zencoder.com/oceans-clip.webm" type='video/webm' />
+    <source src="http://video-js.zencoder.com/oceans-clip.ogv" type='video/ogg' />
+  </video>
+
+  <h2>Set Src programmatically</h2>
+
+  <form>
+    <p>
+      <label>
+        <span>src: </span>
+        <input type="url" name="src" value="http://media.w3.org/2010/05/sintel/trailer.mp4" />
+      </label>
+      <button type="submit">set src</button>
+    </p>
+  </form>
+
+  <h2>Events</h2>
+
+  <ol class="log"></ol>
+
+<script src="app.js"></script>
+</body>
+</html>

--- a/example/inventory-fallback.json
+++ b/example/inventory-fallback.json
@@ -1,0 +1,12 @@
+[
+  {
+    "src": "kitteh.mp4",
+    "type": "video/mp4"
+  },{
+    "src": "superclip.mp4",
+    "type": "video/mp4"
+  }, {
+    "src": "error.mp4",
+    "type": "video/mp4"
+  }
+]

--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -625,6 +625,9 @@ var
               },
               'adserror': function() {
                 this.state = 'content-resuming';
+              },
+              'adsfallback': function() {
+                this.state = 'ads-ready?';
               }
             }
           },
@@ -768,6 +771,7 @@ var
       'adsready',
       'adserror',
       'adscanceled',
+      'adsfallback',
       'adstart',  // startLinearAdMode()
       'adend',    // endLinearAdMode()
       'adskip'    // skipLinearAdMode()

--- a/test/videojs.ads.test.js
+++ b/test/videojs.ads.test.js
@@ -801,6 +801,23 @@ test('adserror in ad-playback transitions to content-playback and triggers adend
   equal(contentPlaybackReason, 'playing', 'The reason for content-playback should have been playing');
 });
 
+test('adsfallback in ad-playback transitions to adsready?', function(){
+  expect(5);
+  equal(player.ads.state, 'content-set');
+  player.trigger('adsready');
+  equal(player.ads.state, 'ads-ready');
+  player.trigger('play');
+  player.ads.startLinearAdMode();
+
+  player.on('adend', function(event) {
+    equal(event.type, 'adend', 'adend should be fired when we enter ads-ready? from adsfallback');
+  });
+
+  player.trigger('adsfallback');
+  equal(player.ads.state, 'ads-ready?');
+  equal(player.ads.triggerevent, 'adsfallback', 'The reason for ads-ready? should have been adsfallback');
+});
+
 test('calling startLinearAdMode() when already in ad-playback does not trigger adstart', function(){
   var adstart = 0;
   player.on('adstart', function() {


### PR DESCRIPTION
Adds the possibility to fallback on another source if current source failed after adstart.

See issue https://github.com/videojs/videojs-contrib-ads/issues/119