### PR TITLE
VJS5 - resuming video tech fix

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -246,6 +246,9 @@ var
       // determine if the video element has loaded enough of the snapshot source
       // to be ready to apply the rest of the state
       tryToResume = function() {
+        // Tech may have changed depending on the differences in sources of the
+        // original video and that of the ad
+        tech = player.el().querySelector('.vjs-tech');
         if (tech.readyState > 1) {
           // some browsers and media aren't "seekable".
           // readyState greater than 1 allows for seeking without exceptions


### PR DESCRIPTION
NOTE: This is for the `vjs-5-upgrade` branch only!!

Because the tech may have changed from the original video to the ad video, we need to make sure we have the correct `tech` object before attempting to resume.

Ex: The video playing is an RTMP stream using the Flash player, the video ad playing was an MP4 (so HTML5), when attempting to resume, we were setting the `tech` variable BEFORE switching the source back to the RTMP stream so the video was never resuming from where it left off.