### PR TITLE
Race canplay event with a setTimeout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - 'iojs-v1'
   - '0.12'
   - '0.10'
+sudo: false
 notifications:
   hipchat:
     rooms:

--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -148,9 +148,22 @@ var
       // determine if the video element has loaded enough of the snapshot source
       // to be ready to apply the rest of the state
       tryToResume = function() {
+
+        // tryToResume can either have been called through the `contentcanplay`
+        // event or fired through setTimeout.
+        // When tryToResume is called, we should make sure to clear out the other
+        // way it could've been called by removing the listener and clearing out
+        // the timeout.
+        player.off('contentcanplay', tryToResume);
+        if (player.ads.tryToResumeTimeout) {
+          player.clearTimeout(player.ads.tryToResumeTimeout);
+          player.ads.tryToResumeTimeout = null;
+        }
+
         // Tech may have changed depending on the differences in sources of the
         // original video and that of the ad
         tech = player.el().querySelector('.vjs-tech');
+
         if (tech.readyState > 1) {
           // some browsers and media aren't "seekable".
           // readyState greater than 1 allows for seeking without exceptions
@@ -211,7 +224,10 @@ var
       // safari requires a call to `load` to pick up a changed source
       player.load();
       // and then resume from the snapshots time once the original src has loaded
+      // in some browsers (firefox) `canplay` may not fire correctly.
+      // Reace the `canplay` event with a timeout.
       player.one('contentcanplay', tryToResume);
+      player.ads.tryToResumeTimeout = player.setTimeout(tryToResume, 2000);
     } else if (!player.ended() || !snapshot.ended) {
       // if we didn't change the src, just restore the tracks
       restoreTracks();

--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -155,9 +155,9 @@ var
         // way it could've been called by removing the listener and clearing out
         // the timeout.
         player.off('contentcanplay', tryToResume);
-        if (player.ads.tryToResumeTimeout) {
-          player.clearTimeout(player.ads.tryToResumeTimeout);
-          player.ads.tryToResumeTimeout = null;
+        if (player.ads.tryToResumeTimeout_) {
+          player.clearTimeout(player.ads.tryToResumeTimeout_);
+          player.ads.tryToResumeTimeout_ = null;
         }
 
         // Tech may have changed depending on the differences in sources of the
@@ -227,7 +227,7 @@ var
       // in some browsers (firefox) `canplay` may not fire correctly.
       // Reace the `canplay` event with a timeout.
       player.one('contentcanplay', tryToResume);
-      player.ads.tryToResumeTimeout = player.setTimeout(tryToResume, 2000);
+      player.ads.tryToResumeTimeout_ = player.setTimeout(tryToResume, 2000);
     } else if (!player.ended() || !snapshot.ended) {
       // if we didn't change the src, just restore the tracks
       restoreTracks();

--- a/test/videojs.ads.snapshot.js
+++ b/test/videojs.ads.snapshot.js
@@ -465,9 +465,9 @@ QUnit.test('player events during snapshot restoration are prefixed', function(as
 });
 
 QUnit.test('tryToResume is called through canplay, removes handler and timeout', function(assert) {
-  let setTimeoutSpy;
-  let offSpy;
-  let clearTimeoutSpy;
+  var setTimeoutSpy;
+  var offSpy;
+  var clearTimeoutSpy;
 
   assert.expect(4);
 
@@ -476,7 +476,7 @@ QUnit.test('tryToResume is called through canplay, removes handler and timeout',
   this.player.trigger('play');
 
   setTimeoutSpy = sinon.spy(window, 'setTimeout');
-  offSpy = sinon.spy(this.player, 'off')
+  offSpy = sinon.spy(this.player, 'off');
   clearTimeoutSpy = sinon.spy(this.player, 'clearTimeout');
 
   // the video plays to time 100
@@ -501,9 +501,9 @@ QUnit.test('tryToResume is called through canplay, removes handler and timeout',
 });
 
 QUnit.test('tryToResume is called through timeout, removes handler and timeout', function(assert) {
-  let setTimeoutSpy;
-  let offSpy;
-  let clearTimeoutSpy;
+  var setTimeoutSpy;
+  var offSpy;
+  var clearTimeoutSpy;
 
   assert.expect(4);
 
@@ -512,7 +512,7 @@ QUnit.test('tryToResume is called through timeout, removes handler and timeout',
   this.player.trigger('play');
 
   setTimeoutSpy = sinon.spy(window, 'setTimeout');
-  offSpy = sinon.spy(this.player, 'off')
+  offSpy = sinon.spy(this.player, 'off');
   clearTimeoutSpy = sinon.spy(this.player, 'clearTimeout');
 
   // the video plays to time 100

--- a/test/videojs.ads.snapshot.js
+++ b/test/videojs.ads.snapshot.js
@@ -48,6 +48,7 @@ QUnit.test('waits for the video to become seekable before restoring the time', f
   // the ad resets the current time
   this.video.currentTime = 0;
   this.player.ads.endLinearAdMode();
+  setTimeoutSpy.callCount = 0; // we call setTimeout an extra time restorePlayerSnapshot
   this.player.trigger('canplay');
   assert.strictEqual(setTimeoutSpy.callCount, 1, 'restoring the time should be delayed');
   assert.strictEqual(this.video.currentTime, 0, 'currentTime is not modified');
@@ -72,6 +73,7 @@ QUnit.test('tries to restore the play state up to 20 times', function(assert) {
   // the ad resets the current time
   this.video.currentTime = 0;
   this.player.ads.endLinearAdMode();
+  setTimeoutSpy.callCount = 0; // we call setTimeout an extra time restorePlayerSnapshot
   this.player.trigger('canplay');
 
   // We expect 20 timeouts at 50ms each.

--- a/test/videojs.ads.snapshot.js
+++ b/test/videojs.ads.snapshot.js
@@ -48,7 +48,7 @@ QUnit.test('waits for the video to become seekable before restoring the time', f
   // the ad resets the current time
   this.video.currentTime = 0;
   this.player.ads.endLinearAdMode();
-  setTimeoutSpy.callCount = 0; // we call setTimeout an extra time restorePlayerSnapshot
+  setTimeoutSpy.reset(); // we call setTimeout an extra time restorePlayerSnapshot
   this.player.trigger('canplay');
   assert.strictEqual(setTimeoutSpy.callCount, 1, 'restoring the time should be delayed');
   assert.strictEqual(this.video.currentTime, 0, 'currentTime is not modified');
@@ -73,7 +73,7 @@ QUnit.test('tries to restore the play state up to 20 times', function(assert) {
   // the ad resets the current time
   this.video.currentTime = 0;
   this.player.ads.endLinearAdMode();
-  setTimeoutSpy.callCount = 0; // we call setTimeout an extra time restorePlayerSnapshot
+  setTimeoutSpy.reset(); // we call setTimeout an extra time restorePlayerSnapshot
   this.player.trigger('canplay');
 
   // We expect 20 timeouts at 50ms each.
@@ -469,7 +469,7 @@ QUnit.test('tryToResume is called through canplay, removes handler and timeout',
   let offSpy;
   let clearTimeoutSpy;
 
-  assert.expect(3);
+  assert.expect(4);
 
   this.video.seekable = [];
   this.player.trigger('adsready');
@@ -487,7 +487,8 @@ QUnit.test('tryToResume is called through canplay, removes handler and timeout',
   // the ad resets the current time
   this.video.currentTime = 0;
   this.player.ads.endLinearAdMode();
-  setTimeoutSpy.callCount = 0; // we call setTimeout an extra time restorePlayerSnapshot
+  assert.strictEqual(setTimeoutSpy.callCount, 1, 'setTimeout is called to race against canplay');
+  setTimeoutSpy.reset(); // we call setTimeout an extra time restorePlayerSnapshot
   this.player.trigger('canplay');
 
   assert.strictEqual(setTimeoutSpy.callCount, 1, 'tryToResume is called');
@@ -504,7 +505,7 @@ QUnit.test('tryToResume is called through timeout, removes handler and timeout',
   let offSpy;
   let clearTimeoutSpy;
 
-  assert.expect(3);
+  assert.expect(4);
 
   this.video.seekable = [];
   this.player.trigger('adsready');
@@ -522,7 +523,8 @@ QUnit.test('tryToResume is called through timeout, removes handler and timeout',
   // the ad resets the current time
   this.video.currentTime = 0;
   this.player.ads.endLinearAdMode();
-  setTimeoutSpy.callCount = 0; // we call setTimeout an extra time restorePlayerSnapshot
+  assert.strictEqual(setTimeoutSpy.callCount, 1, 'setTimeout is called to race against canplay');
+  setTimeoutSpy.reset(); // we call setTimeout an extra time restorePlayerSnapshot
   this.clock.tick(2001);
 
   assert.strictEqual(setTimeoutSpy.callCount, 1, 'tryToResume is called');


### PR DESCRIPTION
In some browsers, like firefox with MSE, canplay doesn't fire at the
correct time. So, we need to race it against a setTimeout so that we
would actually try to resume if canplay doesn't fire correctly.
In the tryToResume function we then clear out the event handler and the
timeout depending on which came back first.

Also, see https://github.com/videojs/videojs-contrib-hls/issues/469