### PR TITLE
Backport fix for MSE HLS src/currentSrc

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -152,7 +152,8 @@ var
       suppressedTracks = [],
       snapshot = {
         ended: player.ended(),
-        src: player.currentSrc(),
+        currentSrc: player.currentSrc(),
+        src: player.src(),
         currentTime: player.currentTime(),
         type: player.currentType()
       };
@@ -296,24 +297,14 @@ var
     // ads, the content player state hasn't been modified and so no
     // restoration is required
 
-    if (player.src()) {
-      // the player was in src attribute mode before the ad and the
-      // src attribute has not been modified, no restoration is required
-      // to resume playback
-      srcChanged = player.src() !== snapshot.src;
-    } else {
-      // the player was configured through source element children
-      // and the currentSrc hasn't changed, no restoration is required
-      // to resume playback
-      srcChanged = player.currentSrc() !== snapshot.src;
-    }
+    srcChanged = player.src() !== snapshot.src || player.currentSrc() !== snapshot.currentSrc;
 
     if (srcChanged) {
       // on ios7, fiddling with textTracks too early will cause safari to crash
       player.one('contentloadedmetadata', restoreTracks);
 
       // if the src changed for ad playback, reset it
-      player.src({ src: snapshot.src, type: snapshot.type });
+      player.src({ src: snapshot.currentSrc, type: snapshot.type });
       // safari requires a call to `load` to pick up a changed source
       player.load();
       // and then resume from the snapshots time once the original src has loaded
@@ -407,7 +398,7 @@ var
           } else if (player.ads.state === 'content-resuming') {
             if (player.ads.snapshot) {
               // the video element was recycled for ad playback
-              if (player.currentSrc() !== player.ads.snapshot.src) {
+              if (player.currentSrc() !== player.ads.snapshot.currentSrc) {
                 if (event.type === 'loadstart') {
                   return;
                 }
@@ -450,7 +441,7 @@ var
     // This will allow ad-integrations from needing to do this themselves.
     player.on(['addurationchange', 'adcanplay'], function() {
       var snapshot = player.ads.snapshot;
-      if (player.currentSrc() === snapshot.src) {
+      if (player.currentSrc() === snapshot.currentSrc) {
         return;  // do nothing
       }
 


### PR DESCRIPTION
This PR is to backport #133 to fix using video.js 5.0 with MSE HLS and the 4.0 to 5.0 compatibility script. 