### PR TITLE
remove class vjs-ad-loading in ad-ready? state

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -462,14 +462,12 @@ var
         },
         'ads-ready?': {
           enter: function() {
-            player.addClass('vjs-ad-loading');
             player.ads.adTimeoutTimeout = window.setTimeout(function() {
               player.trigger('adtimeout');
             }, settings.timeout);
           },
           leave: function() {
             window.clearTimeout(player.ads.adTimeoutTimeout);
-            player.removeClass('vjs-ad-loading');
           },
           events: {
             'play': function() {

--- a/test/videojs.ads.test.js
+++ b/test/videojs.ads.test.js
@@ -190,16 +190,6 @@ QUnit.test('removes the ad-mode class when a preroll finishes', function(assert)
   assert.strictEqual(this.contentPlaybackReason(), 'playing', 'The triggerevent for content-playback should have been playing');
 });
 
-QUnit.test('adds a class while waiting for an ad plugin to load', function(assert) {
-  var el;
-
-  assert.expect(1);
-
-  this.player.trigger('play');
-  el = this.player.el();
-  assert.ok(this.player.hasClass('vjs-ad-loading'), 'the ad loading class should be in "' + el.className + '"');
-});
-
 QUnit.test('adds a class while waiting for a preroll', function(assert) {
   var el;
 


### PR DESCRIPTION
While we are waiting for the ima3 sdk to load in ad-ready? we aren't waiting for an actual ad to load as vjs-ad-loading implies