### PR TITLE
Fix prefixing events when player is preload none

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ And here are the interaction points you use to send information to the ads plugi
 * `ads.endLinearAdMode()` (METHOD) — Call this method to signal that your integration is finished playing linear ads, ready for content video to resume. This method triggers `adend` to be emitted by the player.
 * `ads.skipLinearAdMode()` (METHOD) — Call this method to signal that your integration has received an ad response but is not going to play a linear ad.  This method triggers `adskip` to be emitted by the player.
 * `ads.stitchedAds()` (METHOD) — Get or set the `stitchedAds` setting.
-
+* `ads.videoElementRecycled()` (METHOD) - Returns true if ad playback is taking place in the content element.
 
 In addition, video.js provides a number of events and APIs that might be useful to you.
 For example, the `ended` event signals that the content video has played to completion.

--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ Here are the events that communicate information to your integration from the ad
 
 And here are the interaction points you use to send information to the ads plugin:
 
- * `adsready` (EVENT) — Trigger this event after to signal that your integration is ready to play ads.
- * `adscanceled` (EVENT) — Trigger this event after starting up the player or setting a new video to skip ads entirely. This event is optional; if you always plan on displaying ads, you don't need to worry about triggering it.
- * `adserror` (EVENT) - Trigger this event to indicate that an error in the ad integration has ocurred and any ad states should abort so that content can resume.
+* `adsready` (EVENT) — Trigger this event after to signal that your integration is ready to play ads.
+* `adscanceled` (EVENT) — Trigger this event after starting up the player or setting a new video to skip ads entirely. This event is optional; if you always plan on displaying ads, you don't need to worry about triggering it.
+* `adserror` (EVENT) - Trigger this event to indicate that an error in the ad integration has ocurred and any ad states should abort so that content can resume.
 * `nopreroll` (EVENT) - Trigger this event to indicate that there will be no preroll ad. Otherwise, the player will wait until a timeout occurs before playing content. This event is optional, but can improve user experience.
 * `nopostroll` (EVENT) - Trigger this event to indicate that there will be no postroll ad. Otherwise, contrib-ads will trigger an adtimeout event after content ends if there is no postroll.
- * `ads.startLinearAdMode()` (METHOD) — Call this method to signal that your integration is about to play a linear ad. This method triggers `adstart` to be emitted by the player.
- * `ads.endLinearAdMode()` (METHOD) — Call this method to signal that your integration is finished playing linear ads, ready for content video to resume. This method triggers `adend` to be emitted by the player.
- * `ads.skipLinearAdMode()` (METHOD) — Call this method to signal that your integration has received an ad response but is not going to play a linear ad.  This method triggers `adskip` to be emitted by the player.
+* `ads.startLinearAdMode()` (METHOD) — Call this method to signal that your integration is about to play a linear ad. This method triggers `adstart` to be emitted by the player.
+* `ads.endLinearAdMode()` (METHOD) — Call this method to signal that your integration is finished playing linear ads, ready for content video to resume. This method triggers `adend` to be emitted by the player.
+* `ads.skipLinearAdMode()` (METHOD) — Call this method to signal that your integration has received an ad response but is not going to play a linear ad.  This method triggers `adskip` to be emitted by the player.
+* `ads.stitchedAds()` (METHOD) — Get or set the `stitchedAds` setting.
 
 
 In addition, video.js provides a number of events and APIs that might be useful to you.
@@ -181,6 +182,12 @@ The postrollTimeout should be as short as possible so that the viewer does not h
 Make this longer if your ad integration needs a long time to decide whether it has postroll inventory to play or not.
 Ideally, your ad integration should already know if it wants to play a postroll before the `contentended` event.
 
+### stitchedAds
+
+Type: `boolean`
+Default Value: `false`
+
+Set this to true if you are using ads stitched into the content video. This is necessary for ad events to be sent correctly.
 
 ### debug
 

--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -311,7 +311,10 @@ var
     // when truthy, instructs the plugin to output additional information about
     // plugin state to the video.js log. On most devices, the video.js log is
     // the same as the developer console.
-    debug: false
+    debug: false,
+
+    // set this to true when using ads that are part of the content video
+    stitchedAds: false
   },
 
   adFramework = function(options) {
@@ -351,7 +354,7 @@ var
 
       player.on(videoEvents, function redispatch(event) {
         if (player.ads.state === 'ad-playback') {
-          if (videoElementRecycled(player)) {
+          if (videoElementRecycled(player) || player.ads.stitchedAds()) {
             triggerEvent('ad', event);
           }
         } else if (player.ads.state === 'content-playback' && event.type === 'ended') {
@@ -436,8 +439,17 @@ var
         if (player.ads.state !== 'ad-playback') {
           player.trigger('adskip');
         }
+      },
+
+      stitchedAds: function(arg) {
+        if (arg) {
+          this._stitchedAds = !!arg;
+        }
+        return this._stitchedAds;
       }
     };
+
+    player.ads.stitchedAds(settings.stitchedAds);
 
     fsmHandler = function(event) {
       // Ad Playback State Machine

--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -443,8 +443,16 @@ var
       // We test both src and currentSrc because changing the src attribute to a URL that
       // AdBlocker is intercepting doesn't update currentSrc.
       videoElementRecycled: function() {
-        var srcChanged = player.src() !== this.snapshot.src;
-        var currentSrcChanged = player.currentSrc() !== this.snapshot.currentSrc;
+        var srcChanged;
+        var currentSrcChanged;
+
+        if (!this.snapshot) {
+          return false;
+        }
+
+        srcChanged = player.src() !== this.snapshot.src;
+        currentSrcChanged = player.currentSrc() !== this.snapshot.currentSrc;
+
         return srcChanged || currentSrcChanged;
       }
     };

--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -432,7 +432,7 @@ var
       },
 
       stitchedAds: function(arg) {
-        if (arg) {
+        if (arg !== undefined) {
           this._stitchedAds = !!arg;
         }
         return this._stitchedAds;

--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -345,15 +345,21 @@ var
         });
       };
 
+      function videoElementRecycled(player) {
+        return player.currentSrc() !== player.ads.snapshot.currentSrc;
+      }
+
       player.on(videoEvents, function redispatch(event) {
         if (player.ads.state === 'ad-playback') {
-          triggerEvent('ad', event);
+          if (videoElementRecycled(player)) {
+            triggerEvent('ad', event);
+          }
         } else if (player.ads.state === 'content-playback' && event.type === 'ended') {
           triggerEvent('content', event);
         } else if (player.ads.state === 'content-resuming') {
           if (player.ads.snapshot) {
             // the video element was recycled for ad playback
-            if (player.currentSrc() !== player.ads.snapshot.currentSrc) {
+            if (videoElementRecycled(player)) {
               if (event.type === 'loadstart') {
                 return;
               }

--- a/test/videojs.ads.test.js
+++ b/test/videojs.ads.test.js
@@ -952,6 +952,35 @@ QUnit.test('player events during postrolls are prefixed if tech is reused for ad
   assert.strictEqual(prefixed.callCount, 6, 'prefixed events fired');
 });
 
+QUnit.test('player events during stitched ads are prefixed', function(assert) {
+  var prefixed, unprefixed;
+
+  assert.expect(2);
+
+  prefixed = sinon.spy();
+  unprefixed = sinon.spy();
+
+  this.player.ads.stitchedAds(true);
+
+  // play a midroll
+  this.player.trigger('play');
+  this.player.trigger('adsready');
+  this.player.trigger('adtimeout');
+  this.player.ads.startLinearAdMode();
+
+  // simulate video events that should be prefixed
+  this.player.on(['loadstart', 'playing', 'pause', 'ended', 'firstplay', 'loadedalldata'], unprefixed);
+  this.player.on(['adloadstart', 'adplaying', 'adpause', 'adended', 'adfirstplay', 'adloadedalldata'], prefixed);
+  this.player.trigger('firstplay');
+  this.player.trigger('loadstart');
+  this.player.trigger('playing');
+  this.player.trigger('loadedalldata');
+  this.player.trigger('pause');
+  this.player.trigger('ended');
+  assert.strictEqual(unprefixed.callCount, 0, 'no unprefixed events fired');
+  assert.strictEqual(prefixed.callCount, 6, 'prefixed events fired');
+});
+
 QUnit.test('player events during content playback are not prefixed', function(assert) {
   var prefixed, unprefixed;
 

--- a/test/videojs.ads.test.js
+++ b/test/videojs.ads.test.js
@@ -856,7 +856,7 @@ QUnit.test('adsready in content-playback triggers readyforpreroll', function(ass
 // Event prefixing during ad playback
 // ----------------------------------
 
-QUnit.test('player events during prerolls are prefixed', function(assert) {
+QUnit.test('player events during prerolls are prefixed if tech is reused for ad', function(assert) {
   var prefixed, unprefixed;
 
   assert.expect(2);
@@ -872,6 +872,10 @@ QUnit.test('player events during prerolls are prefixed', function(assert) {
   this.player.trigger('play');
   this.player.trigger('adsready');
 
+  this.player.ads.snapshot = {
+    currentSrc: 'something'
+  };
+
   // simulate video events that should be prefixed
   this.player.on(['loadstart', 'playing', 'pause', 'ended', 'firstplay', 'loadedalldata'], unprefixed);
   this.player.on(['adloadstart', 'adplaying', 'adpause', 'adended', 'adfirstplay', 'adloadedalldata'], prefixed);
@@ -885,7 +889,7 @@ QUnit.test('player events during prerolls are prefixed', function(assert) {
   assert.strictEqual(prefixed.callCount, 6, 'prefixed events fired');
 });
 
-QUnit.test('player events during midrolls are prefixed', function(assert) {
+QUnit.test('player events during midrolls are prefixed if tech is reused for ad', function(assert) {
   var prefixed, unprefixed;
 
   assert.expect(2);
@@ -899,6 +903,10 @@ QUnit.test('player events during midrolls are prefixed', function(assert) {
   this.player.trigger('adtimeout');
   this.player.ads.startLinearAdMode();
 
+  this.player.ads.snapshot = {
+    currentSrc: 'something'
+  };
+
   // simulate video events that should be prefixed
   this.player.on(['loadstart', 'playing', 'pause', 'ended', 'firstplay', 'loadedalldata'], unprefixed);
   this.player.on(['adloadstart', 'adplaying', 'adpause', 'adended', 'adfirstplay', 'adloadedalldata'], prefixed);
@@ -912,7 +920,7 @@ QUnit.test('player events during midrolls are prefixed', function(assert) {
   assert.strictEqual(prefixed.callCount, 6, 'prefixed events fired');
 });
 
-QUnit.test('player events during postrolls are prefixed', function(assert) {
+QUnit.test('player events during postrolls are prefixed if tech is reused for ad', function(assert) {
   var prefixed, unprefixed;
 
   assert.expect(2);
@@ -926,6 +934,10 @@ QUnit.test('player events during postrolls are prefixed', function(assert) {
   this.player.trigger('adtimeout');
   this.player.trigger('ended');
   this.player.ads.startLinearAdMode();
+
+  this.player.ads.snapshot = {
+    currentSrc: 'something'
+  };
 
   // simulate video events that should be prefixed
   this.player.on(['loadstart', 'playing', 'pause', 'ended', 'firstplay', 'loadedalldata'], unprefixed);


### PR DESCRIPTION
Related: https://github.com/videojs/video.js/pull/2957 (necessary for this to work in HLS after the src has been changed by a third party)