### PR TITLE
After postroll, seek to the actual player duration. If we are beyond …

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -738,7 +738,7 @@ var
               }
             },
             'contentended': function() {
-              if(player.ads.snapshot && player.ads.snapshot.ended){
+              if (player.ads.snapshot && player.ads.snapshot.ended) {
                 // player has already been here. content has really ended. good-bye
                 return;
               }

--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -156,7 +156,7 @@ var
             player.currentTime(currentTime);
           }
         } else {
-          player.currentTime(snapshot.currentTime);
+          player.currentTime(snapshot.ended ? player.duration() : snapshot.currentTime);
         }
 
         // Resume playback if this wasn't a postroll
@@ -738,6 +738,10 @@ var
               }
             },
             'contentended': function() {
+              if(player.ads.snapshot && player.ads.snapshot.ended){
+                // player has already been here. content has really ended. good-bye
+                return;
+              }
               this.state = 'postroll?';
             }
           }


### PR DESCRIPTION
…snapshot.ended and the `postroll?` state has already been consumed, say good-bye