### PR TITLE
Fix no ended event after content source is changed.

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -757,6 +757,12 @@ var
               } else {
                 this.state = 'ads-ready?';
               }
+              // When a new source is loaded into the player, we should remove the snapshot
+              // to avoid confusing player state with the new content's state
+              // i.e When new content is set, the player should fire the ended event
+              if (this.snapshot && this.snapshot.ended) {
+                this.snapshot = null;
+              }
             },
             'contentended': function() {
               if (player.ads.snapshot && player.ads.snapshot.ended) {


### PR DESCRIPTION
# Description
Previously, if a new source is given to the player after the 'ended' event has been triggered, the 'ended' event will not fire again.

# Changes Proposed
Removing reference to snapshot when a contentupdate is observed during content playback.