### PR TITLE
Fix for metrics on empty ad

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/videojs/videojs-contrib-ads.git"
   },
-  "version": "3.3.11",
+  "version": "3.3.12-0",
   "author": {
     "name": "Brightcove"
   },

--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -412,6 +412,10 @@ var
       endLinearAdMode: function() {
         if (player.ads.state === 'ad-playback') {
           player.trigger('adend');
+          // In the case of an empty ad response, we want to make sure that
+          // the vjs-ad-loading class is always removed. We could probably check for
+          // duration on adPlayer for an empty ad but we remove it here just to make sure
+          player.removeClass('vjs-ad-loading');
         }
       },
 


### PR DESCRIPTION
**Issue Description:**

When you get an empty ad, we do not properly remove the `vjs-ad-loading` class, which causes the Player to not handle the ad state correctly.

The effect of this is that the player feels it's always in ad mode.

**Fix Description:**

In the current state of things, we do not have proper logic to check for an empty ad, because of which the `vjs-ad-loading` class is not removed properly.
Currently we are removing `vjs-ad-loading` class on pre-roll, ads-ready and post-rolls, but don't have anything for empty ad. This fix should take care of that.

This fix makes sure that when we are in `endLinearAdMode` , after triggering `adend`, the `vjs-ad-loading` class is always removed.
