### PR TITLE
fix check to reset snapshot on contentupdate

### DIFF
--- a/src/videojs.ads.js
+++ b/src/videojs.ads.js
@@ -762,7 +762,7 @@ var
               // When a new source is loaded into the player, we should remove the snapshot
               // to avoid confusing player state with the new content's state
               // i.e When new content is set, the player should fire the ended event
-              if (this.snapshot && this.snapshot.ended) {
+              if (this.snapshot && (this.snapshot.ended || this.state === 'content-set')) {
                 this.snapshot = null;
               }
             },


### PR DESCRIPTION
**Issue:** When switching from a VOD source to a LIVE source using a playlist, the ads snapshot from the VOD remains while the live content is playing. This leaves content-playback in a weird state where timeupdate events are not passed along to the player while the LIVE content is playing - due to the fact that contrib-ads is waiting for the original video to play back.  Playback eventually fails with a PLAYER_ERR_TIMEOUT after 45 seconds of apparent inactivity even though the live video has been playing.

**Root Cause:** The check to determine if the snapshot should be cleared in the contentupdate event handler in the FSM only checks if there is a snapshot and if the snapshot has ended, ie. the content video has ended. This doesn't capture the scenario where the source changed but the original video had not completed.

**Suggested fix:** Change the conditional to check if there is a snapshot, and if that snapshot has ended OR we are in content-set state indicating a new source was loaded into the player.

