### PR TITLE
Fix for content-play behind ad on Android

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -266,6 +266,11 @@ const contribAdsPlugin = function(options) {
           player.ads.adTimeoutTimeout = window.setTimeout(function() {
             player.trigger('adtimeout');
           }, settings.prerollTimeout);
+          // We will try to pause content here. This is because in an autoadvance playlist
+          // on Android devices with HLS renditions, the duration is incorrectly reported
+          // as infinity, due to which the content is not paused incorrectly
+          // So before we signal to the ad plugin , we want to pause content
+          cancelContentPlay(player);
           // signal to ad plugin that it's their opportunity to play a preroll
           player.trigger('readyforpreroll');
         }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -266,12 +266,6 @@ const contribAdsPlugin = function(options) {
           player.ads.adTimeoutTimeout = window.setTimeout(function() {
             player.trigger('adtimeout');
           }, settings.prerollTimeout);
-          // We will try to pause content here. This is because in an autoadvance playlist
-          // on Android devices with HLS renditions, the duration is incorrectly reported
-          // as infinity, due to which the content is not paused incorrectly
-          // So before we signal to the ad plugin , we want to pause content
-          cancelContentPlay(player);
-          // signal to ad plugin that it's their opportunity to play a preroll
           player.trigger('readyforpreroll');
         }
       },
@@ -502,6 +496,12 @@ const contribAdsPlugin = function(options) {
           this.state = 'ad-playback';
         },
         contentupdate() {
+          // We know sources have changed, so we call CancelContentPlay
+          // to avoid playback of video in the background of an ad. Playback Occurs on
+          // an Android device if we do not call cancelContentPlay
+          if(!player.ads.shouldPlayContentBehindAd(player)) {
+            cancelContentPlay(player);
+          }
           if (player.paused()) {
             this.state = 'content-set';
           } else {
@@ -520,11 +520,6 @@ const contribAdsPlugin = function(options) {
             return;
           }
           this.state = 'postroll?';
-        },
-        play() {
-          if (player.currentSrc() !== player.ads.contentSrc) {
-            cancelContentPlay(player);
-          }
         }
       }
     }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -266,6 +266,7 @@ const contribAdsPlugin = function(options) {
           player.ads.adTimeoutTimeout = window.setTimeout(function() {
             player.trigger('adtimeout');
           }, settings.prerollTimeout);
+          // signal to ad plugin that it's their opportunity to play a preroll
           player.trigger('readyforpreroll');
         }
       },
@@ -498,7 +499,11 @@ const contribAdsPlugin = function(options) {
         contentupdate() {
           // We know sources have changed, so we call CancelContentPlay
           // to avoid playback of video in the background of an ad. Playback Occurs on
-          // an Android device if we do not call cancelContentPlay
+          // Android devices if we do not call cancelContentPlay. This is because
+          // the sources do not get updated in time on Android due to timing issues.
+          // So instead of checking if the sources have changed in the play handler
+          // and calling cancelContentPlay() there we call it here.
+          // This does not happen on Desktop as the sources do get updated in time.
           if(!player.ads.shouldPlayContentBehindAd(player)) {
             cancelContentPlay(player);
           }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -342,6 +342,13 @@ const contribAdsPlugin = function(options) {
         // add css to the element to indicate and ad is playing.
         player.addClass('vjs-ad-playing');
 
+        // We should remove the vjs-live class if it has been added in order to 
+        // show the adprogress control bar on Android devices for falsely
+        // determined LIVE videos due to the duration incorrectly reported as Infinity
+        if (player.hasClass('vjs-live')) {
+          player.removeClass('vjs-live');
+        }
+
         // remove the poster so it doesn't flash between ads
         removeNativePoster(player);
 
@@ -358,6 +365,13 @@ const contribAdsPlugin = function(options) {
       },
       leave() {
         player.removeClass('vjs-ad-playing');
+
+        // We should add the vjs-live class back if the video is a LIVE video
+        // If we dont do this, then for a LIVE Video, we will get an incorrect
+        // styled control, which displays the time for the video
+        if (player.ads.isLive(player)) {
+         player.addClass('vjs-live');
+        }
         if (!player.ads.shouldPlayContentBehindAd(player)) {
           snapshot.restorePlayerSnapshot(player, this.snapshot);
         }

--- a/test/videojs.ads.test.js
+++ b/test/videojs.ads.test.js
@@ -1051,4 +1051,24 @@ QUnit.test('shouldPlayContentBehindAd', function(assert) {
 
 });
 
+QUnit.test('Check incorrect addition of vjs-live during ad-playback', function(assert) {
+  this.player.trigger('play');
+  this.player.ads.startLinearAdMode();
+  assert.strictEqual(this.player.hasClass('vjs-live'), false, 'We have the correct class');
+  
+});
+
+QUnit.test('Check for existence of vjs-live after ad-end for LIVE videos',
+  function(assert) {
+    this.player.trigger('adstart');
+    this.player.ads.startLinearAdMode();
+    this.player.ads.state = 'ad-playback';
+    this.player.duration = function() {return Infinity;};
+    this.player.ads.endLinearAdMode();
+    this.player.trigger('playing');
+    assert.strictEqual(this.player.ads.isLive(this.player), true, 'Content is LIVE');
+    assert.ok(this.player.hasClass('vjs-live'), 'We should be having vjs-live class here');
+    
+});
+
 }(window, window.QUnit));


### PR DESCRIPTION
Proposal:
This is a proposal fix for preventing content from playing in the background while an Ad is playing on an Android device within a playlist.

The current issue is that if you have an auto-advance playlist containing HLS videos, the duration of the video when the Ad starts is given as Infinity erroneously on Android devices(I have tested this on v5.x and v6.x), and the content does not stop when a pre-roll is playing.

The idea is to pause playback of the content before we signal the ad plugin to play a pre-roll.
