### PR TITLE
Add import of videojs in cancelContentPlay.js

### DIFF
--- a/src/cancelContentPlay.js
+++ b/src/cancelContentPlay.js
@@ -5,6 +5,8 @@ It does this by pausing the player immediately after a "play" where ads will be 
 then signalling that we should play after the ad is done.
 */
 
+import videojs from 'video.js';
+
 const cancelContentPlay = function(player) {
   if (player.ads.cancelPlayTimeout) {
     // another cancellation is already in flight, so do nothing


### PR DESCRIPTION
This import was probably forgotten. In most situations where videojs is available in the global scope this wouldn't have resulted in any issues, but when packaging everything with Webpack or Browserify this is not always the case.

Because of this bug using videojs-contrib-ads with Webpack currently breaks. A patch release would be much appreciated!