### PR TITLE
blank div to prevent content flash covers ad on iPad

### DIFF
--- a/src/cancelContentPlay.js
+++ b/src/cancelContentPlay.js
@@ -14,7 +14,7 @@ const cancelContentPlay = function(player) {
   }
 
   // Avoid content flash on non-iPad iOS
-  if (videojs.browser.IS_IOS) {
+  if ((videojs.browser.IS_IOS) && (!videojs.browser.IS_IPAD)) {
 
     const width = player.currentWidth ? player.currentWidth() : player.width();
     const height = player.currentHeight ? player.currentHeight() : player.height();

--- a/src/cancelContentPlay.js
+++ b/src/cancelContentPlay.js
@@ -14,7 +14,7 @@ const cancelContentPlay = function(player) {
   }
 
   // Avoid content flash on non-iPad iOS
-  if ((videojs.browser.IS_IOS) && (!videojs.browser.IS_IPAD)) {
+  if (videojs.browser.IS_IOS && videojs.browser.IS_IPHONE) {
 
     const width = player.currentWidth ? player.currentWidth() : player.width();
     const height = player.currentHeight ? player.currentHeight() : player.height();


### PR DESCRIPTION
Description: In cancelContentPlay, there is code to hide the video element and overlay a black filled div over the video player until 'adplaying', 'adtimeout', 'adserror', 'adscanceled', 'adskip', or 'playing' fires at which point the div is hidden and the video element made visible.

Existing code: This was happening in IMA3 and FW and in Chrome or Safari on the iPad. This code currently tests whether or not to run by checking videojs.browser.IS_IOS.

Proposed change: This is not sufficient as we also need to make sure it is NOT an iPad. This fix modifies the check to test for videojs.browser.IS_IOS && !videojs.browser.IS_IPAD.

Expected behavior:
1. Load video with preroll ad in browser on iPad
2. Preroll ad loads and plays, ad is visible, audio is audible
3. Content plays

Actual behavior:
1. Load video with preroll ad in browser on iPad
2. Preroll ad loads and plays, ad is NOT visible, audio is audible
3. Content plays

Tested this using the current versions of Freewheel AND IMA3 on:

iPad iOS 10.1.1 with Safari
iPad iOS 10.1.1 with Chrome 54.0.2840.91

iPhone iOS 10.1.1 with Safari*
iPhone iOS 10.1.1 with Chrome

Desktop Mac OS X El Capitan Safari  10.0.1 (11602.2.14.0.7)
Desktop Mac OS X El Capitan Chrome 54.0.2840.71

NOTE: On IMA3 on the iPhone, I see a content flash/poster before the video plays, which is weird because the code should run on iPhone since IS_IOS and !IS_IPAD should both be true.  TESTING with the original player on iPhone also shows this behavior though so it does not appear to be added by this change.  The original test player DOES have the black div above the player in iPad though.
