### PR TITLE
Fix to prevent clickthrough when progress bar is clicked

### DIFF
--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -4,7 +4,7 @@ Styles for ad integrations.
 
 // Prevent seeking during ad playback
 .vjs-ad-playing.vjs-ad-playing .vjs-progress-control {
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 // Make the progress bar yellow for ads

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -4,7 +4,20 @@ Styles for ad integrations.
 
 // Prevent seeking during ad playback
 .vjs-ad-playing.vjs-ad-playing .vjs-progress-control {
+  pointer-events: none;
+}
+
+// Make the progress control pseudo element transparent and enable pointer-events
+// This ensures a transparent layer on top of the ad progress bar thus making sure
+// clickthroughs are prevented and also users do not interact with the actual
+// ad progress control
+.vjs-ad-playing.vjs-ad-playing .vjs-progress-control::after {
   pointer-events: auto;
+  background: transparent;
+  top: -0.5em;
+  width: 100%;
+  position: inherit;
+  content: "\000a0"
 }
 
 // Make the progress bar yellow for ads


### PR DESCRIPTION
**Proposal:**
This is a proposal fix to prevent the click through from happening when user clicks on the progress control.

**Current situation:**
What currently happens when user clicks on the progress control is when the user clicks on the progress control, it takes you to the ad-clickthrough page.

**Fix proposal:**
What should happen when user clicks on the progress control - nothing.

I have tested this across multiple platforms, and devices and the ad-clickthrough seems to be prevented with this fix.
