### PR TITLE
Fix for ended event not firing again on seeking back

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -536,6 +536,10 @@ const contribAdsPlugin = function(options) {
         contentended() {
           if (player.ads.snapshot && player.ads.snapshot.ended) {
             // player has already been here. content has really ended. good-bye
+            // Also if after the video ends, user scrubs back and tries to play content, 
+            // we need to set the ad state to the following in order to generate the 
+            // ended event again on replay of the video without a reload of the page
+            this.state = 'content-resuming';
             return;
           }
           this.state = 'postroll?';


### PR DESCRIPTION
**Problem statement:**

Using IMA or FW after the video ends , if you scrub back and seek backwards a bit and let the video play and reach to the end, the 'ended' event does not fire again.

**Issue:**

The problem is that at the moment when such a condition as above occurs, we don't do anything as the following becomes true

> if (player.ads.snapshot && player.ads.snapshot.ended) {
>     // player has already been here. content has really ended. good-bye
>     return;
>  }

**Proposal Fix:**

This fix attempts to address the issue of fixing the ended event by attaching a state when the content ends, which makes the ad-state workflow go into the content-resuming state, which in turn triggers the ended event, and in the end returns back to the content-playback state which the player was before. 
So as result this fix essentially resolves the symptom of ended event not being fired again by not disrupting the ad-workflow as we return the player back to content-playback state