### PR TITLE
Fix placehoder div on ios10 playsinline

### DIFF
--- a/src/cancelContentPlay.js
+++ b/src/cancelContentPlay.js
@@ -32,16 +32,16 @@ const cancelContentPlay = function(player) {
     player.el_.style.display = 'none';
 
     // Unhide the player and remove the placeholder once we're ready to move on.
-    player.one(['adplaying', 'adtimeout', 'adserror', 'adscanceled', 'adskip',
+    player.one(['adstart', 'adplaying', 'adtimeout', 'adserror', 'adscanceled', 'adskip',
                 'playing'], function() {
       player.el_.style.display = 'block';
       placeholder.remove();
     });
 
-    // Detect fullscreen change, remove placeholder and show player.
-    // On iOS 10 Safari is supposed to also add playsinline to the player
+    // Detect fullscreen change, if returning from fullscreen and placeholder exists,
+    // remove placeholder and show player whether or not playsinline was attached.
     player.on('fullscreenchange', function () {
-      if (placeholder) {
+      if (placeholder && player.hasClass('vjs-fullscreen')) {
         player.el_.style.display = 'block';
         placeholder.remove();
       }

--- a/src/cancelContentPlay.js
+++ b/src/cancelContentPlay.js
@@ -38,10 +38,10 @@ const cancelContentPlay = function(player) {
       placeholder.remove();
     });
 
-    // On iOS 10 on iPhone, playsinline is added when pinching to return from
-    // fullscreen. Detect fullscreen change, remove placeholder and show player.
+    // Detect fullscreen change, remove placeholder and show player.
+    // On iOS 10 Safari is supposed to also add playsinline to the player
     player.on('fullscreenchange', function () {
-      if (player.el_.hasAttribute('playsinline') && placeholder) {
+      if (placeholder) {
         player.el_.style.display = 'block';
         placeholder.remove();
       }

--- a/src/cancelContentPlay.js
+++ b/src/cancelContentPlay.js
@@ -37,6 +37,16 @@ const cancelContentPlay = function(player) {
       player.el_.style.display = 'block';
       placeholder.remove();
     });
+
+    // On iOS 10 on iPhone, playsinline is added when pinching to return from
+    // fullscreen. Detect fullscreen change, remove placeholder and show player.
+    player.on('fullscreenchange', function () {
+      if (player.el_.hasAttribute('playsinline') && placehoder) {
+        player.el_.style.display = 'block';
+        placeholder.remove();
+      }
+    })
+
   }
 
   // The timeout is necessary because pausing a video element while processing a `play`

--- a/src/cancelContentPlay.js
+++ b/src/cancelContentPlay.js
@@ -13,7 +13,7 @@ const cancelContentPlay = function(player) {
     return;
   }
 
-  // Avoid content flash on non-iPad iOS
+  // Avoid content flash on non-iPad iOS and iPhones on iOS10 with playsinline
   if ((videojs.browser.IS_IOS && videojs.browser.IS_IPHONE) && !player.el_.hasAttribute('playsinline')) {
 
     const width = player.currentWidth ? player.currentWidth() : player.width();

--- a/src/cancelContentPlay.js
+++ b/src/cancelContentPlay.js
@@ -14,7 +14,7 @@ const cancelContentPlay = function(player) {
   }
 
   // Avoid content flash on non-iPad iOS
-  if (videojs.browser.IS_IOS && videojs.browser.IS_IPHONE) {
+  if ((videojs.browser.IS_IOS && videojs.browser.IS_IPHONE) && (!player.el_.hasAttribute('playsinline'))) {
 
     const width = player.currentWidth ? player.currentWidth() : player.width();
     const height = player.currentHeight ? player.currentHeight() : player.height();

--- a/src/cancelContentPlay.js
+++ b/src/cancelContentPlay.js
@@ -14,7 +14,7 @@ const cancelContentPlay = function(player) {
   }
 
   // Avoid content flash on non-iPad iOS
-  if ((videojs.browser.IS_IOS && videojs.browser.IS_IPHONE) && (!player.el_.hasAttribute('playsinline'))) {
+  if ((videojs.browser.IS_IOS && videojs.browser.IS_IPHONE) && !player.el_.hasAttribute('playsinline')) {
 
     const width = player.currentWidth ? player.currentWidth() : player.width();
     const height = player.currentHeight ? player.currentHeight() : player.height();
@@ -41,7 +41,7 @@ const cancelContentPlay = function(player) {
     // On iOS 10 on iPhone, playsinline is added when pinching to return from
     // fullscreen. Detect fullscreen change, remove placeholder and show player.
     player.on('fullscreenchange', function () {
-      if (player.el_.hasAttribute('playsinline') && placehoder) {
+      if (player.el_.hasAttribute('playsinline') && placeholder) {
         player.el_.style.display = 'block';
         placeholder.remove();
       }


### PR DESCRIPTION
This fix adds a check for playsinline on iPhone to determine whether to add the black div used to cover the content player and prevent flash of content/poster.  Without this fix, a player with playsinline on an iPhone with iOS10 shows the black div over the player preventing the ad from being viewed.  

The black div would also appear on iPhones on iOS10 without playsinline - in this case, the div remains visible after returning from fullscreen during a paused ad and before content begins playing. Added a check for playsinline and the placeholder on fullscreenchange to remove the div and show the player.

To test scenario 1: 

- setup player with playsinline and ad plugin (ima3 or freewhee)
- play video on iPhone with iOS 10
Before fix: black div covers ad
After fix: black div is never presented over ad before playing ad

Risk: potential to have content-flash when playing inline without the div to cover the poster/content player

To test scenario 2: 

- setup player without playsinline
- play content fullscreen on iPhone with iOS 10
- during ad pause and/or pinch to close ad player
Before fix: black div covers ad when returning from fullscreen
After fix: div is hidden and content player begins content when ad is complete

