### PR TITLE
prevent ios10 preroll autoplay playsinline without muted

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -214,23 +214,22 @@ const contribAdsPlugin = function(options) {
     // to autoplay the ad.  Also pauses the player if it has started playing and
     // removes the autoplay attribute or player setting.
     cancelAutoplayAdOnIOS(somePlayer) {
-      if( videojs.IS_IPHONE && player.el_.hasAttribute('playsinline')
-        && (player.autoplay() || player.el_.hasAttribute('autoplay'))
-        && (!player.muted() || !player.el_.hasAttribute('muted'))) {
+      if (videojs.IS_IPHONE && player.el_.hasAttribute('playsinline') &&
+        (player.autoplay() || player.el_.hasAttribute('autoplay')) &&
+        (!player.muted() || !player.el_.hasAttribute('muted'))) {
 
-          if (!player.paused()) {
-            player.pause();
-          }
-          if (player.autoplay() === true) {
-            player.autoplay(false);
-          }
-          if (player.el_.hasAttribute('autoplay')) {
-            player.el_.removeAttribute('autoplay');
-          }
+        if (!player.paused()) {
+          player.pause();
+        }
+        if (player.autoplay() === true) {
+          player.autoplay(false);
+        }
+        if (player.el_.hasAttribute('autoplay')) {
+          player.el_.removeAttribute('autoplay');
+        }
         return true;
-      } else {
-        return false;
       }
+      return false;
     }
   };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -261,10 +261,8 @@ const contribAdsPlugin = function(options) {
             cancelContentPlay(player);
             // remove the poster so it doesn't flash between videos
             removeNativePoster(player);
-          } else {
-            if (!player.paused()) {
-              player.pause();
-            }
+          } else if (!player.paused()) {
+            player.pause();
           }
         },
         adserror() {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -256,6 +256,9 @@ const contribAdsPlugin = function(options) {
           this.state = 'ads-ready';
         },
         play() {
+          // play should only be triggered in content-set for initial
+          // playback using an autoplay player. Normally, play occurs
+          // during ads-ready, ads-ready?, or preroll?
           if (!player.ads.cancelAutoplayAdOnIOS(player)) {
             this.state = 'ads-ready?';
             cancelContentPlay(player);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -213,14 +213,12 @@ const contribAdsPlugin = function(options) {
     // and muted attributes or player settings. Otherwise, we should attempt
     // to autoplay the ad.  Also pauses the player if it has started playing and
     // removes the autoplay attribute or player setting.
+    // Can be replaced when this is fixed: https://github.com/videojs/video.js/issues/3970
     cancelAutoplayAdOnIOS(somePlayer) {
       if (videojs.IS_IPHONE && player.el_.hasAttribute('playsinline') &&
         (player.autoplay() || player.el_.hasAttribute('autoplay')) &&
         (!player.muted() || !player.el_.hasAttribute('muted'))) {
 
-        if (!player.paused()) {
-          player.pause();
-        }
         if (player.autoplay() === true) {
           player.autoplay(false);
         }
@@ -263,6 +261,10 @@ const contribAdsPlugin = function(options) {
             cancelContentPlay(player);
             // remove the poster so it doesn't flash between videos
             removeNativePoster(player);
+          } else {
+            if (!player.paused()) {
+              player.pause();
+            }
           }
         },
         adserror() {


### PR DESCRIPTION
On iOS 10, if the player has the playsinline attribute and is configured to autoplay, but is not muted, we currently try to autoplay the ad. In content-set -> play, we cancelContentPlay and hide the native poster to prepare for playback - however the native browser on IOS prevents the ad from loading.

This results in a loading spinner for the duration of the ad or until the ad times out at which point the player presents the big play button and poster for the content.

This fix adds a new function cancelAutoplayAdOnIOS which will check to see if the player is on an iPhone, has autoplay, playsinline and muted attributes - if so, we remove the autoplay attribute/setting, pause the player and return true to indicate canceling the autoplay of the ad.

Otherwise, we simply perform the original tasks of setting the state to ads-ready?, call cancelContentPlay and removeNativePoster.
