### PR TITLE
Fix nopostroll event

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -491,6 +491,12 @@ const contribAdsPlugin = function(options) {
             player.trigger('ended');
           }, 1);
         },
+        nopostroll() {
+          this.state = 'content-resuming';
+          window.setTimeout(function() {
+            player.trigger('ended');
+          }, 1);
+        },
         contentupdate() {
           this.state = 'ads-ready?';
         }
@@ -633,7 +639,8 @@ const contribAdsPlugin = function(options) {
     'adsready',
     'adserror',
     'adscanceled',
-    'nopreroll'
+    'nopreroll',
+    'nopostroll'
 
   ]), processEvent);
 

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -934,6 +934,15 @@ QUnit.test('ad impl can notify contrib-ads there is no postroll', function(asser
 
 });
 
+QUnit.test('ad impl can notify contrib-ads there is no postroll even after contentended', function(assert) {
+
+  this.player.ads.state = 'postroll?';
+  this.player.trigger('contentended');
+  this.player.trigger('nopostroll');
+  assert.strictEqual(this.player.ads.state, 'content-resuming', 'no longer in postroll?');
+
+});
+
 QUnit.test('ended event is sent with postroll', function(assert) {
 
   var ended = sinon.spy();


### PR DESCRIPTION
When triggering `nopostroll` event after `contentended` in `postroll?` state, it was not directly falling back to `content-resuming` state. It only works with  `adtimeout` or `adskip` events. Event was missing in state object for `postroll?` state. I think it is handy to have this event after `contentended` especially when I request postroll break at that time so I added it and updated test suite for it.