### PR TITLE
Remove error throwing for live videos.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -183,8 +183,7 @@ const contribAdsPlugin = function(options) {
     // AdBlocker is intercepting doesn't update currentSrc.
     videoElementRecycled() {
       if (!this.snapshot) {
-        throw new Error(
-          'You cannot use videoElementRecycled while there is no snapshot.');
+        return false;
       }
 
       const srcChanged = player.tech_.src() !== this.snapshot.src;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -182,8 +182,13 @@ const contribAdsPlugin = function(options) {
     // We test both src and currentSrc because changing the src attribute to a URL that
     // AdBlocker is intercepting doesn't update currentSrc.
     videoElementRecycled() {
-      if (!this.snapshot) {
+      if (player.ads.shouldPlayContentBehindAd(player)) {
         return false;
+      }
+
+      if (!this.snapshot) {
+        throw new Error(
+          'You cannot use videoElementRecycled while there is no snapshot.');
       }
 
       const srcChanged = player.tech_.src() !== this.snapshot.src;


### PR DESCRIPTION
For live videos error is thrown after ad is shown. I found [here](https://github.com/videojs/videojs-contrib-ads/blob/v3.3.13/src/videojs.ads.js#L448) that in previous version `false` was returned instead of throwing an error.