### PR TITLE
Add withCredentials property to snapshot

### DIFF
--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -48,8 +48,7 @@ export function getPlayerSnapshot(player) {
     snapshotObject.nativePoster = tech.poster;
     snapshotObject.style = tech.getAttribute('style');
 
-    // Why does `player.currentSource().withCredentials` work but not `player.tech_.currentSource_.withCredentials`?
-    if (player.currentSource().withCredentials) {
+    if (player.currentSource().withCredentials !== undefined) {
       snapshotObject.withCredentials = player.currentSource().withCredentials;
     }
   }
@@ -207,7 +206,7 @@ export function restorePlayerSnapshot(player, snapshotObject) {
 
     // if the src changed for ad playback, reset it
     // only restore withCredentials if it is in the snapshot
-    if (snapshotObject.withCredentials) {
+    if ('withCredentials' in snapshotObject) {
       player.src({ src: snapshotObject.currentSrc, type: snapshotObject.type, withCredentials: snapshotObject.withCredentials });
     } else {
       player.src({ src: snapshotObject.currentSrc, type: snapshotObject.type });

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -45,6 +45,9 @@ export function getPlayerSnapshot(player) {
   if (tech) {
     snapshotObject.nativePoster = tech.poster;
     snapshotObject.style = tech.getAttribute('style');
+    if (player.tech_.currentSource_.withCredentials) {
+      snapshotObject.withCredentials = player.tech_.currentSource_.withCredentials;
+    }
   }
 
   for (let i = 0; i < remoteTracks.length; i++) {
@@ -199,7 +202,7 @@ export function restorePlayerSnapshot(player, snapshotObject) {
     player.one('contentloadedmetadata', restoreTracks);
 
     // if the src changed for ad playback, reset it
-    player.src({ src: snapshotObject.currentSrc, type: snapshotObject.type });
+    player.src({ src: snapshotObject.currentSrc, type: snapshotObject.type, withCredentials: snapshotObject.withCredentials });
     // safari requires a call to `load` to pick up a changed source
     player.load();
     // and then resume from the snapshots time once the original src has loaded

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -35,7 +35,6 @@ export function getPlayerSnapshot(player) {
   const suppressedRemoteTracks = [];
   const suppressedTracks = [];
 
-  // Why not just include `currentSource: player.currentSource()` to get the whole object?
   const snapshotObject = {
     ended: player.ended(),
     currentSrc: player.currentSrc(),

--- a/test/test.snapshot.js
+++ b/test/test.snapshot.js
@@ -34,6 +34,67 @@ QUnit.test('restores the original video src after ads', function(assert) {
   assert.strictEqual(this.player.currentSrc(), originalSrc, 'the original src is restored');
 });
 
+// QUnit.test('if withCredentials is present, restores the original video src withCredentials', function(assert) {
+//   var originalSource = {
+//     type: "application/x-mpegURL",
+//     src: "http://example.com/original.mp4",
+//     withCredentials: true
+//   }
+//
+//   assert.expect(1);
+//
+//   this.player.src(originalSource);
+//
+//   // this.player.trigger('adsready');
+//   // this.player.trigger('play');
+//   // this.player.ads.startLinearAdMode();
+//   // this.player.src('//example.com/ad.mp4');
+//   // this.player.ads.endLinearAdMode();
+//   assert.deepEqual(this.player.currentSource(), originalSource, 'the original src is restored withCredentials');
+// });
+
+QUnit.test('if withCredentials is present, restores the original video src withCredentials', function(assert) {
+  var updatedSrc;
+
+  this.player.currentSrc = function() {
+    return 'content.mp4';
+  };
+
+  this.player.currentType = function() {
+    return 'video/mp4';
+  };
+
+  this.player.currentSource  = function() {
+    return {type: 'video/mp4', src: 'content.mp4', withCredentials: true}
+  }
+
+  this.player.trigger('adsready');
+  this.player.trigger('play');
+  this.player.ads.startLinearAdMode();
+
+  // `src` gets called internally to set the source back to its original
+  // value when the player snapshot is restored when `endLinearAdMode`
+  // is called.
+  this.player.tech_.src = function(source) {
+    if (source === undefined) {
+      return 'ad.mp4';
+    }
+    updatedSrc = source;
+  };
+
+  this.player.src = function(source) {
+    if (source === undefined) {
+      return 'ad.mp4';
+    }
+    updatedSrc = source;
+  };
+
+
+  this.player.ads.endLinearAdMode();
+  this.player.trigger('playing');
+  assert.deepEqual(updatedSrc, {type: 'video/mp4', src: 'content.mp4', withCredentials: true}, 'withCredentials restored');
+});
+
 QUnit.test('waits for the video to become seekable before restoring the time', function(assert) {
   var setTimeoutSpy;
 

--- a/test/test.snapshot.js
+++ b/test/test.snapshot.js
@@ -34,25 +34,6 @@ QUnit.test('restores the original video src after ads', function(assert) {
   assert.strictEqual(this.player.currentSrc(), originalSrc, 'the original src is restored');
 });
 
-// QUnit.test('if withCredentials is present, restores the original video src withCredentials', function(assert) {
-//   var originalSource = {
-//     type: "application/x-mpegURL",
-//     src: "http://example.com/original.mp4",
-//     withCredentials: true
-//   }
-//
-//   assert.expect(1);
-//
-//   this.player.src(originalSource);
-//
-//   // this.player.trigger('adsready');
-//   // this.player.trigger('play');
-//   // this.player.ads.startLinearAdMode();
-//   // this.player.src('//example.com/ad.mp4');
-//   // this.player.ads.endLinearAdMode();
-//   assert.deepEqual(this.player.currentSource(), originalSource, 'the original src is restored withCredentials');
-// });
-
 QUnit.test('if withCredentials is present, restores the original video src withCredentials', function(assert) {
   var updatedSrc;
 
@@ -64,8 +45,8 @@ QUnit.test('if withCredentials is present, restores the original video src withC
     return 'video/mp4';
   };
 
-  this.player.currentSource  = function() {
-    return {type: 'video/mp4', src: 'content.mp4', withCredentials: true}
+  this.player.currentSource = function() {
+    return {type: 'video/mp4', src: 'content.mp4', withCredentials: true};
   }
 
   this.player.trigger('adsready');
@@ -89,10 +70,50 @@ QUnit.test('if withCredentials is present, restores the original video src withC
     updatedSrc = source;
   };
 
-
   this.player.ads.endLinearAdMode();
   this.player.trigger('playing');
   assert.deepEqual(updatedSrc, {type: 'video/mp4', src: 'content.mp4', withCredentials: true}, 'withCredentials restored');
+});
+
+QUnit.test('if withCredentials is NOT present, restores the original video src without withCredentials', function(assert) {
+  var updatedSrc;
+
+  this.player.currentSrc = function() {
+    return 'content.mp4';
+  };
+
+  this.player.currentType = function() {
+    return 'video/mp4';
+  };
+
+  this.player.currentSource = function() {
+    return {type: 'video/mp4', src: 'content.mp4'};
+  }
+
+  this.player.trigger('adsready');
+  this.player.trigger('play');
+  this.player.ads.startLinearAdMode();
+
+  // `src` gets called internally to set the source back to its original
+  // value when the player snapshot is restored when `endLinearAdMode`
+  // is called.
+  this.player.tech_.src = function(source) {
+    if (source === undefined) {
+      return 'ad.mp4';
+    }
+    updatedSrc = source;
+  };
+
+  this.player.src = function(source) {
+    if (source === undefined) {
+      return 'ad.mp4';
+    }
+    updatedSrc = source;
+  };
+
+  this.player.ads.endLinearAdMode();
+  this.player.trigger('playing');
+  assert.deepEqual(updatedSrc, {type: 'video/mp4', src: 'content.mp4'}, 'restored without withCredentials');
 });
 
 QUnit.test('waits for the video to become seekable before restoring the time', function(assert) {


### PR DESCRIPTION
### Description
The snapshot doesn't currently copy the `withCredentials` property from `.currentSource()`, which can prevent the playback of tokened content after a preroll. This PR will add conditional logic to `snapshot.js` that will ensure `withCredentials` is copied and restored to the source object between ads and main content.

#### Alternatively...
A better longterm solution might be to modify the snapshot to copy `player.currentSource()`, an object that itself contains a number of the source properties that right now are copied individually within the snapshot. Copying and restoring all of `player.currentSource()` would guarantee the restoration of important source properties like `withCredentials`, any DRM key systems, etc, and remove the need for more conditional logic in `snapshot.js` to handle those properties.
```js
  const snapshotObject = {
    ended: player.ended(),
    currentSrc: player.currentSrc(),
    src: player.tech_.src(),
    currentTime,
    type: player.currentType()
  };
```
would become something like...
```js
  const snapshotObject = {
    sourceObject: player.currentSource(),
    ended: player.ended(),
    src: player.tech_.src(),
    currentTime,
  };
```
Just a thought.