### PR TITLE
Clear registered timeouts when player is disposed.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -641,6 +641,25 @@ const contribAdsPlugin = function(options) {
 
   ]), processEvent);
 
+  // Clear timeouts when player is disposed
+  player.on('dispose', function() {
+    if (player.ads.adTimeoutTimeout) {
+      window.clearTimeout(player.ads.adTimeoutTimeout);
+    }
+
+    if (player.ads._fireEndedTimeout) {
+      window.clearTimeout(player.ads._fireEndedTimeout);
+    }
+
+    if (player.ads.cancelPlayTimeout) {
+      window.clearTimeout(player.ads.cancelPlayTimeout);
+    }
+
+    if (player.ads.tryToResumeTimeout_) {
+      player.clearTimeout(player.ads.tryToResumeTimeout_);
+    }
+  });
+
   // If we're autoplaying, the state machine will immidiately process
   // a synthetic play event
   if (!player.paused()) {


### PR DESCRIPTION
Sometimes when player is disposed there is an error like this:
```js
Uncaught TypeError: Cannot read property 'vdata1495796386723' of null
    at Object.hasElData (dom.js:335)
    at Object.trigger (events.js:390)
    at Player.trigger (component.js:816)
    at plugin.js:323
```
As we can see here https://github.com/videojs/videojs-contrib-ads/blob/master/src/plugin.js#L323 when window timeouts are not cleared after dispose `video.js` could not find the reference to player to trigger the event.