### PR TITLE
fix issue where captions were showing during ads on iOS

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -175,7 +175,7 @@ const contribAdsPlugin = function(options) {
     // TODO reset state to content-set here instead of in every contentupdate case
     reset() {
       const textTrackList = player.textTracks();
-      
+
       textTrackList.removeEventListener('change', player.ads.snapshot.trackChangeHandler);
       player.ads.disableNextSnapshotRestore = false;
       player.ads._contentEnding = false;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -179,7 +179,7 @@ const contribAdsPlugin = function(options) {
 
         textTrackList.removeEventListener('change', player.ads.snapshot.trackChangeHandler);
       }
-      
+
       player.ads.disableNextSnapshotRestore = false;
       player.ads._contentEnding = false;
       player.ads._contentHasEnded = false;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -174,9 +174,12 @@ const contribAdsPlugin = function(options) {
 
     // TODO reset state to content-set here instead of in every contentupdate case
     reset() {
-      const textTrackList = player.textTracks();
+      if (player.ads.snapshot.trackChangeHandler) {
+        const textTrackList = player.textTracks();
 
-      textTrackList.removeEventListener('change', player.ads.snapshot.trackChangeHandler);
+        textTrackList.removeEventListener('change', player.ads.snapshot.trackChangeHandler);
+      }
+      
       player.ads.disableNextSnapshotRestore = false;
       player.ads._contentEnding = false;
       player.ads._contentHasEnded = false;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -174,12 +174,6 @@ const contribAdsPlugin = function(options) {
 
     // TODO reset state to content-set here instead of in every contentupdate case
     reset() {
-      if (player.ads.snapshot.trackChangeHandler) {
-        const textTrackList = player.textTracks();
-
-        textTrackList.removeEventListener('change', player.ads.snapshot.trackChangeHandler);
-      }
-
       player.ads.disableNextSnapshotRestore = false;
       player.ads._contentEnding = false;
       player.ads._contentHasEnded = false;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -174,6 +174,9 @@ const contribAdsPlugin = function(options) {
 
     // TODO reset state to content-set here instead of in every contentupdate case
     reset() {
+      const textTrackList = player.textTracks();
+      textTrackList.removeEventListener('change', player.ads.snapshot.trackChangeHandler);
+
       player.ads.disableNextSnapshotRestore = false;
       player.ads._contentEnding = false;
       player.ads._contentHasEnded = false;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -175,8 +175,8 @@ const contribAdsPlugin = function(options) {
     // TODO reset state to content-set here instead of in every contentupdate case
     reset() {
       const textTrackList = player.textTracks();
+      
       textTrackList.removeEventListener('change', player.ads.snapshot.trackChangeHandler);
-
       player.ads.disableNextSnapshotRestore = false;
       player.ads._contentEnding = false;
       player.ads._contentHasEnded = false;

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -71,7 +71,7 @@ export function getPlayerSnapshot(player) {
 
   // iOS Safari will change caption mode to 'showing' if a user previously
   // turned captions on manually for that video source, so this will re-disable
-  // them if that occurs during ad playback
+  // them in case that occurs during ad playback
   if (videojs.browser.IS_IOS && !Array.isArray(tracks)) {
     tracks.one('change', function(event) {
       if (player.ads.state === 'ad-playback') {

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -88,7 +88,7 @@ export function getPlayerSnapshot(player) {
     }
   };
 
-  if (videojs.browser.IS_IOS && !Array.isArray(tracks)) {
+  if (videojs.browser.IS_IOS && player.tech_.featuresNativeTextTracks && !Array.isArray(tracks)) {
     tracks.addEventListener('change', iOSTrackListChangeHandler);
   }
 
@@ -120,7 +120,7 @@ export function restorePlayerSnapshot(player, snapshotObject) {
 
   // ensures that the iOS TextTrackList 'change' listener added in getPlayerSnapshot()
   // doesn't persist into main content
-  if (videojs.browser.IS_IOS) {
+  if (videojs.browser.IS_IOS && player.tech_.featuresNativeTextTracks) {
     const tracks = player.textTracks();
 
     tracks.removeEventListener('change', snapshotObject.trackChangeHandler);

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -70,10 +70,10 @@ export function getPlayerSnapshot(player) {
   snapshotObject.suppressedTracks = suppressedTracks;
 
   // iOS Safari will change caption mode to 'showing' if a user previously
-  // turned captions on manually for that source, so this will re-disable them
-  // if that occurs during ad playback
+  // turned captions on manually for that video source, so this will re-disable
+  // them if that occurs during ad playback
   if (videojs.browser.IS_IOS && !Array.isArray(tracks)) {
-    tracks.one('change', function trackChangeHandler(event) {
+    tracks.one('change', function(event) {
       if (player.ads.state === 'ad-playback') {
         const trackList = event.target.tracks_;
 
@@ -111,9 +111,12 @@ export function restorePlayerSnapshot(player, snapshotObject) {
   const suppressedRemoteTracks = snapshotObject.suppressedRemoteTracks;
   const suppressedTracks = snapshotObject.suppressedTracks;
 
-  // remove iOS TextTrackList 'change' listener added in getPlayerSnapshot()
+  // ensures that the iOS TextTrackList 'change' listener added in getPlayerSnapshot()
+  // doesn't persist into main content
   if (videojs.browser.IS_IOS) {
-    suppressedTracks.off('change', trackChangeHandler);
+    const tracks = player.textTracks();
+
+    tracks.off('change');
   }
 
   let trackSnapshot;

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -69,6 +69,24 @@ export function getPlayerSnapshot(player) {
   }
   snapshotObject.suppressedTracks = suppressedTracks;
 
+  // iOS Safari will change caption mode to 'showing' or 'hidden' under certain conditions,
+  // so this will re-disable them during ad playback in those cases.
+
+  // do we need to check that tracks is not an empty array (as seen in its declaration above)?
+  tracks.on('change', function changeHandler(event) {
+    if (player.ads.state === 'ad-playback') {
+      const trackList = event.target.tracks_;
+
+      trackList.forEach(track => {
+        if (track.mode === 'showing' || track.mode === 'hidden') {
+          track.mode = 'disabled';
+          console.log('track mode changed back to disabled');
+        }
+      })
+    }
+    this.off('change', changeHandler);
+  })
+
   return snapshotObject;
 }
 

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -81,7 +81,7 @@ export function getPlayerSnapshot(player) {
           if (track.mode === 'showing') {
             track.mode = 'disabled';
           }
-        })
+        });
       }
     });
   }
@@ -131,7 +131,6 @@ export function restorePlayerSnapshot(player, snapshotObject) {
       trackSnapshot.track.mode = trackSnapshot.mode;
     }
   };
-
 
   // finish restoring the playback state
   const resume = function() {

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -89,7 +89,7 @@ export function getPlayerSnapshot(player) {
   };
 
   if (videojs.browser.IS_IOS && !Array.isArray(tracks)) {
-    tracks.on('change', iOSTrackListChangeHandler);
+    tracks.addEventListener('change', iOSTrackListChangeHandler);
   }
 
   snapshotObject.trackChangeHandler = iOSTrackListChangeHandler;
@@ -104,7 +104,6 @@ export function getPlayerSnapshot(player) {
  * @param {Object} snapshotObject - the player state to apply
  */
 export function restorePlayerSnapshot(player, snapshotObject) {
-
   if (player.ads.disableNextSnapshotRestore === true) {
     player.ads.disableNextSnapshotRestore = false;
     return;
@@ -124,7 +123,7 @@ export function restorePlayerSnapshot(player, snapshotObject) {
   if (videojs.browser.IS_IOS) {
     const tracks = player.textTracks();
 
-    tracks.off('change', snapshotObject.trackChangeHandler);
+    tracks.removeEventListener('change', snapshotObject.trackChangeHandler);
   }
 
   let trackSnapshot;

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -86,7 +86,7 @@ export function getPlayerSnapshot(player) {
         }
       }
     }
-  }
+  };
 
   if (videojs.browser.IS_IOS && !Array.isArray(tracks)) {
     tracks.on('change', iOSTrackListChangeHandler);

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -89,7 +89,7 @@ export function getPlayerSnapshot(player) {
   }
 
   if (videojs.browser.IS_IOS && !Array.isArray(tracks)) {
-    tracks.one('change', iOSTrackListChangeHandler);
+    tracks.on('change', iOSTrackListChangeHandler);
   }
 
   snapshotObject.trackChangeHandler = iOSTrackListChangeHandler;

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -75,7 +75,7 @@ export function getPlayerSnapshot(player) {
    * 'change' event handler will re-disable them in case that occurs during ad playback
    */
   const iOSTrackListChangeHandler = function() {
-    if (player.ads.state === 'ad-playback') {
+    if (player.ads.isAdPlaying()) {
       const textTrackList = player.textTracks();
 
       for (let i = 0; i < textTrackList.length; i++) {

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -78,7 +78,7 @@ export function getPlayerSnapshot(player) {
         const trackList = event.target.tracks_;
 
         trackList.forEach(track => {
-          if (track.mode === 'showing' || track.mode === 'hidden') {
+          if (track.mode === 'showing') {
             track.mode = 'disabled';
           }
         })

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -13,6 +13,7 @@ function initialize(player) {
       const textTrackList = player.textTracks();
 
       textTrackList.removeEventListener('change', player.ads.snapshot.trackChangeHandler);
+      player.ads.snapshotIOSTrackHandlerAdded_ = false;
     }
   });
 
@@ -105,7 +106,10 @@ export function getPlayerSnapshot(player) {
   };
 
   if (videojs.browser.IS_IOS && player.tech_.featuresNativeTextTracks && !Array.isArray(tracks)) {
-    tracks.addEventListener('change', iOSTrackListChangeHandler);
+    if (!player.ads.snapshotIOSTrackHandlerAdded_) {
+      tracks.addEventListener('change', iOSTrackListChangeHandler);
+      player.ads.snapshotIOSTrackHandlerAdded_ = true;
+    }
   }
 
   snapshotObject.trackChangeHandler = iOSTrackListChangeHandler;
@@ -140,6 +144,7 @@ export function restorePlayerSnapshot(player, snapshotObject) {
     const tracks = player.textTracks();
 
     tracks.removeEventListener('change', snapshotObject.trackChangeHandler);
+    player.ads.snapshotIOSTrackHandlerAdded_ = false;
   }
 
   let trackSnapshot;

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -71,21 +71,21 @@ export function getPlayerSnapshot(player) {
 
   // iOS Safari will change caption mode to 'showing' or 'hidden' under certain conditions,
   // so this will re-disable them during ad playback in those cases.
+  if (!Array.isArray(tracks)) {
+    tracks.on('change', function changeHandler(event) {
+      if (player.ads.state === 'ad-playback') {
+        const trackList = event.target.tracks_;
 
-  // do we need to check that tracks is not an empty array (as seen in its declaration above)?
-  tracks.on('change', function changeHandler(event) {
-    if (player.ads.state === 'ad-playback') {
-      const trackList = event.target.tracks_;
-
-      trackList.forEach(track => {
-        if (track.mode === 'showing' || track.mode === 'hidden') {
-          track.mode = 'disabled';
-          console.log('track mode changed back to disabled');
-        }
-      })
-    }
-    this.off('change', changeHandler);
-  })
+        trackList.forEach(track => {
+          if (track.mode === 'showing' || track.mode === 'hidden') {
+            track.mode = 'disabled';
+            console.log('track mode changed back to disabled');
+          }
+        })
+      }
+      this.off('change', changeHandler);
+    });
+  }
 
   return snapshotObject;
 }

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -7,6 +7,18 @@ import window from 'global/window';
 
 import videojs from 'video.js';
 
+function initialize(player) {
+  player.on('contentupdate', function() {
+    if (player.ads.snapshot.trackChangeHandler) {
+      const textTrackList = player.textTracks();
+
+      textTrackList.removeEventListener('change', player.ads.snapshot.trackChangeHandler);
+    }
+  });
+
+  player.ads.snapshotInitialized_ = true;
+}
+
 /**
  * Returns an object that captures the portions of player state relevant to
  * video playback. The result of this function can be passed to
@@ -15,6 +27,10 @@ import videojs from 'video.js';
  * @param {Object} player The videojs player object
  */
 export function getPlayerSnapshot(player) {
+
+  if (player.ads.snapshotInitialized_ === undefined) {
+    initialize(player);
+  }
 
   let currentTime;
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -55,7 +55,7 @@ module.exports = function(config) {
     autoWatch: false,
     singleRun: true,
     concurrency: 1,
-    browserNoActivityTimeout: 20000,
+    browserNoActivityTimeout: 300000,
     client: {
       qunit: {
         testTimeout: 10000
@@ -63,4 +63,3 @@ module.exports = function(config) {
     }
   });
 };
-


### PR DESCRIPTION
## About
These additions address a behavior in iOS Safari that can result in captions displaying during ad playback: 

When a user manually turns on native captions in the fullscreen iOS player, "the device will set an internal preference at the OS level for captions in that language. This preference survives clearing the browser cache and rebooting the phone” (from the Video.js [docs](https://github.com/videojs/video.js/wiki/Text-Tracks-Browser-Behavior#ios)). Safari evidently associates this caption preference with that specific video source and `srclang` (I haven't been able to find this in any Apple documentation, but the behavior observed while debugging this issue is pretty conclusive evidence that this is the case).

So, if a user manually turns on native captions _during ad playback_, then watches that same ad on the same device again without native captions explicitly set to ‘Off,’ Safari will switch the caption TextTrack `mode` from `"disabled"` (set by the snapshot at the beginning of ad playback) to `"showing"`.

## Solution

Fair warning: it's a bit of a hack, but possibly the only straight-forward way to have a player react to this iOS behavior. At the time the snapshot is taken and ad playback begins, add a `change` event listener to the player's `TextTrackList`. If a `change` event occurs while an ad is playing and any of the text track modes are `"showing"`, reset them to `"disabled"`. When the snapshot is restored, remove the event listener to ensure it doesn't persist into main content if there was no `change` event.

### *Limitations of this approach
Unfortunately there is no easy way to determine if a _user_ or _Safari_ has initiated a given track mode change, so in addition to re-disabling tracks that are enabled by Safari, this code will also disable any track that is enabled by a user during ad playback.

**Final Note:** I also changed the `browserNoActivityTimeout` in `karma.conf.js` from 20 seconds to 5 minutes to match the config in Video.js. I was not able to run tests or push my branch because the timeout was too short.


