### PR TITLE
feat: add a cancelContentTimeout option

### DIFF
--- a/src/cancelContentPlay.js
+++ b/src/cancelContentPlay.js
@@ -58,6 +58,9 @@ export default function cancelContentPlay(player) {
 
   }
 
+  if (!player.ads.doCancelPlayTimeout) {
+    return;
+  }
   // The timeout is necessary because pausing a video element while processing a `play`
   // event on iOS can cause the video element to continuously toggle between playing and
   // paused states.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -59,7 +59,11 @@ const defaults = {
   debug: false,
 
   // set this to true when using ads that are part of the content video
-  stitchedAds: false
+  stitchedAds: false,
+
+  // asynchronously pause the player during ad loading
+  // if the player is playing
+  doCancelPlayTimeout: true
 };
 
 const contribAdsPlugin = function(options) {
@@ -332,6 +336,7 @@ const contribAdsPlugin = function(options) {
 
   player.ads.cueTextTracks = cueTextTracks;
   player.ads.adMacroReplacement = adMacroReplacement.bind(player);
+  player.ads.doCancelPlayTimeout = settings.doCancelPlayTimeout;
 
   // Start sending contentupdate events for this player
   initializeContentupdate(player);


### PR DESCRIPTION
This is a workaround for a problem that we are seeing which is going to be rather hard to solve. 

The basic gist comes from this line of code: 
https://github.com/videojs/videojs-contrib-ads/blob/master/src/cancelContentPlay.js#L69

A play promise is in flight as this code runs so the player is not technically playing (although it will be). So we think that we need to pause the video for contrib-ads loading. This cancels the promise and the state of play is lost. This causes the play button to show back up during a preroll even though the user just clicked it.