### PR TITLE
fix: content restarts from the beginning when snapshot restores source after midroll in iOS

### DIFF
--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -130,7 +130,7 @@ export function restorePlayerSnapshot(player, snapshotObject) {
       player.play();
     }
 
-    // if we added autoplay to force content preloading on iOS, remove it now
+    // if we added autoplay to force content loading on iOS, remove it now
     // that it has served its purpose
     if (player.ads.shouldRemoveAutoplay_) {
       player.autoplay(false);
@@ -204,8 +204,8 @@ export function restorePlayerSnapshot(player, snapshotObject) {
     // on ios7, fiddling with textTracks too early will cause safari to crash
     player.one('contentloadedmetadata', restoreTracks);
 
-    // Adding autoplay guarantees that Safari will preload the content so we can
-    // seek back to the correct time before playing it
+    // adding autoplay guarantees that Safari will load the content so we can
+    // seek back to the correct time after ads
     if (videojs.browser.IS_IOS && !player.autoplay()) {
       player.autoplay(true);
 

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -134,7 +134,7 @@ export function restorePlayerSnapshot(player, snapshotObject) {
     // that it has served its purpose
     if (player.ads.shouldRemoveAutoplay_) {
       player.autoplay(false);
-      player.ads.shouldRemoveAutoplay_ = null;
+      player.ads.shouldRemoveAutoplay_ = false;
     }
   };
 
@@ -204,8 +204,8 @@ export function restorePlayerSnapshot(player, snapshotObject) {
     // on ios7, fiddling with textTracks too early will cause safari to crash
     player.one('contentloadedmetadata', restoreTracks);
 
-    // This guarantees that Safari will preload the content so we can seek to
-    // the proper time before playing it
+    // Adding autoplay guarantees that Safari will preload the content so we can
+    // seek back to the correct time before playing it
     if (videojs.browser.IS_IOS && !player.autoplay()) {
       player.autoplay(true);
 


### PR DESCRIPTION
## Problem
When the snapshot [restores the content source](https://github.com/videojs/videojs-contrib-ads/blob/master/src/snapshot.js#L256) following ad playback, the `currentTime` is not able to be set in iOS, causing the content to restart from the beginning following midrolls. Even with `preload="auto"`, Safari loads only the video metadata, so [we do not get a `contentcanplay` player event](https://github.com/videojs/videojs-contrib-ads/blob/master/src/snapshot.js#L261) and [setting the `currentTime`](https://github.com/videojs/videojs-contrib-ads/blob/master/src/snapshot.js#L180) fails to seek the content.

## Possible, albeit hacky solution
`player.load()` does not seem to make the content seekable in iOS. We still only get a `contentloadedmetadata` event, and setting the `currentTime` still fails. So far, the only way I have been able to override Safari's default preloading behavior is to add `autoplay` to the video element before changing the source. This way, we do get a `contentcanplay` event and the content is seekable by the time we try to update the `currentTime`. `autoplay` is then removed after the content starts playing.

### Note:
This feels far from the ideal solution, but so far it's the only way I've been able to force Safari to load the content enough that we can seek. I am hoping others might have some better ideas (paging @incompl and @gkatsev). At the very least I wanted to start a conversation about how best to address this problem.