### PR TITLE
fix: TypeError - player.ads.snapshot.trackChangeHandler

### DIFF
--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -9,7 +9,7 @@ import videojs from 'video.js';
 
 function initialize(player) {
   player.on('contentupdate', function() {
-    if (player.ads.snapshot.trackChangeHandler) {
+    if (player.ads.snapshot && player.ads.snapshot.trackChangeHandler) {
       const textTrackList = player.textTracks();
 
       textTrackList.removeEventListener('change', player.ads.snapshot.trackChangeHandler);


### PR DESCRIPTION
This will fix `VIDEOJS: ERROR: TypeError: Cannot read property 'trackChangeHandler' of null` errors on `contentupdate` events when the snapshot is not used.