### PR TITLE
fix: snapshot.trackChangeHandler is undefined

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -336,9 +336,6 @@ const contribAdsPlugin = function(options) {
   // Start sending contentupdate events for this player
   initializeContentupdate(player);
 
-  // Prepare the snapshot feature for use during ad playback
-  snapshot.initializeSnapshot(player);
-
   // Global contentupdate handler for resetting plugin state
   player.on('contentupdate', player.ads.reset);
 
@@ -813,9 +810,7 @@ const contribAdsPlugin = function(options) {
       player.clearTimeout(player.ads.tryToResumeTimeout_);
     }
 
-    if (player.ads._trackChangeDuringAdsHandler) {
-      player.textTracks().removeEventListener('change', player.ads._trackChangeDuringAdsHandler);
-    }
+    player.textTracks().removeEventListener('change', player.ads._trackChangeDuringAdsHandler);
   });
 
   // If we're autoplaying, the state machine will immidiately process

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -777,7 +777,9 @@ const contribAdsPlugin = function(options) {
   };
 
   // Add the listener to the text track list
-  player.textTracks().addEventListener('change', textTrackChangeHandler);
+  player.ready(function() {
+    player.textTracks().addEventListener('change', textTrackChangeHandler);
+  });
 
   // Register our handler for the events that the state machine will process
   player.on(VIDEO_EVENTS.concat([

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -336,6 +336,9 @@ const contribAdsPlugin = function(options) {
   // Start sending contentupdate events for this player
   initializeContentupdate(player);
 
+  // Prepare the snapshot feature for use during ad playback
+  snapshot.initializeSnapshot(player);
+
   // Global contentupdate handler for resetting plugin state
   player.on('contentupdate', player.ads.reset);
 

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -44,7 +44,6 @@ export function initializeSnapshot(player) {
   };
 
   player.ads._trackChangeDuringSnapshotHandler = iOSTrackListChangeHandler;
-  player.ads._snapshotInitialized = true;
 }
 
 /**
@@ -55,11 +54,6 @@ export function initializeSnapshot(player) {
  * @param {Object} player The videojs player object
  */
 export function getPlayerSnapshot(player) {
-
-  if (player.ads._snapshotInitialized === undefined) {
-    initializeSnapshot(player);
-  }
-
   let currentTime;
 
   if (videojs.browser.IS_IOS && player.ads.isLive(player)) {

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -9,7 +9,8 @@ import videojs from 'video.js';
 
 function initialize(player) {
   player.on('contentupdate', function() {
-    if (player.ads.snapshot.trackChangeHandler) {
+    if (player.ads.snapshotIOSTrackHandlerAdded_ &&
+      player.ads.snapshot && player.ads.snapshot.trackChangeHandler) {
       const textTrackList = player.textTracks();
 
       textTrackList.removeEventListener('change', player.ads.snapshot.trackChangeHandler);

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -7,10 +7,6 @@ import window from 'global/window';
 
 import videojs from 'video.js';
 
-export function initializeSnapshot(player) {
-
-}
-
 /**
  * Returns an object that captures the portions of player state relevant to
  * video playback. The result of this function can be passed to

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -3,13 +3,10 @@ module.exports = function(config) {
     enabled: false,
     usePhantomJS: false,
     postDetection: function(browsers) {
-      var i = browsers.indexOf('Safari');
-
-      if (i !== -1) {
-        browsers.splice(i, 1);
-      }
-
-      return browsers;
+      const toRemove = ['Safari', 'SafariTechPreview'];
+      return browsers.filter((e) => {
+        return toRemove.indexOf(e) === -1;
+      });
     }
   };
 

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -1191,7 +1191,8 @@ if (videojs.browser.IS_IOS) {
 
     }.bind(this));
 
-    // The mode should go back to disabled when the change happens
+    // The mode should go back to disabled when the change event happens as
+    // during ad playback we do not want the content captions to be visible on iOS
     tracks.on('change', function() {
       assert.equal(tracks[0].mode, 'disabled', 'Mode is reset to disabled');
 

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -1169,3 +1169,39 @@ QUnit.test('adserror ends linear ad mode ', function(assert) {
   this.player.trigger('adserror');
   assert.strictEqual(this.player.ads._inLinearAdMode, false, 'after adserror');
 });
+
+if (videojs.browser.IS_IOS) {
+  QUnit.test('Check the trackChangeDuringAdHandler takes effect on iOS', function(assert) {
+    const tracks = this.player.textTracks();
+
+    // Since addTextTrack is async, wait for the addtrack event
+    tracks.on('addtrack', function() {
+
+      // Confirm the track is added, set the mode to showing
+      assert.equal(tracks.length, 1);
+      tracks[0].mode = 'showing';
+      assert.equal(tracks[0].mode, 'showing',  'Initial state is showing');
+
+      // Start the ad, confirm the track is disabled
+      this.player.ads.startLinearAdMode();
+      assert.equal(tracks[0].mode, 'disabled', 'Snapshot sets tracks to disabled');
+
+      // Force the mode to showing
+      tracks[0].mode = 'showing';
+
+    }.bind(this));
+
+    // The mode should go back to disabled when the change happens
+    tracks.on('change', function() {
+      assert.equal(tracks[0].mode, 'disabled', 'Mode is reset to disabled');
+
+      // End the ad, check the track mode is showing again
+      this.player.ads.endLinearAdMode();
+      assert.equal(tracks[0].mode, 'showing', 'Mode is restored after ad');
+    }.bind(this));
+
+    this.player.trigger('play');
+    this.player.trigger('adsready');
+    this.player.addTextTrack('captions', 'English', 'en');
+  });
+}

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -1171,7 +1171,7 @@ QUnit.test('adserror ends linear ad mode ', function(assert) {
 });
 
 if (videojs.browser.IS_IOS) {
-  QUnit.test('Check the trackChangeDuringAdHandler takes effect on iOS', function(assert) {
+  QUnit.test('Check the textTrackChangeHandler takes effect on iOS', function(assert) {
     const tracks = this.player.textTracks();
 
     // Since addTextTrack is async, wait for the addtrack event

--- a/test/test.snapshot.js
+++ b/test/test.snapshot.js
@@ -440,7 +440,8 @@ QUnit.test('Snapshot and text tracks', function(assert) {
   assert.equal(this.player.textTracks()[0].language, 'es');
   assert.equal(this.player.textTracks()[0].mode, 'disabled');
 
-  // Double check that the track remains disabled
+  // Double check that the track remains disabled after 3s
+  this.clock.tick(3000);
   assert.equal(this.player.remoteTextTracks()[0].mode, 'disabled');
   assert.equal(this.player.textTracks()[0].mode, 'disabled');
 

--- a/test/test.snapshot.js
+++ b/test/test.snapshot.js
@@ -377,12 +377,15 @@ QUnit.test('Snapshot and text tracks', function(assert) {
       label: label,
       language: language,
       mode: 'showing',
-      addEventListener: function() {}
+      addEventListener: function() {},
+      removeEventListener: function() {}
     });
   }
   this.player.textTracks = function() {
     return mockTracks;
   }
+  this.player.textTracks().addEventListener = function() {};
+  this.player.textTracks().removeEventListener = function() {};
 
   // Add a text track
   this.player.addRemoteTextTrack({
@@ -456,3 +459,91 @@ QUnit.test('Snapshot and text tracks', function(assert) {
   this.player.addTextTrack = originalAddTrack;
   this.player.textTracks = originalTextTracks;
 });
+
+QUnit.test('Event Listeners added in snapshots are removed as expected', function(assert) {
+  const mockHandler = sinon.spy();
+  const originalHandler = this.player.ads._trackChangeDuringSnapshotHandler;
+  const tracks = this.player.textTracks();
+
+  // Replace the handler with the mock
+  this.player.ads._trackChangeDuringSnapshotHandler = mockHandler;
+
+  // Check that the snapshot hasn't been created and 
+  // the handler hasn't been added to the track list yet
+  assert.ok(!this.player.ads.snapshot);
+  assert.ok(!this.player.ads._snapshotIOSTrackHandlerAdded);
+  videojs.trigger(tracks, 'change');
+  assert.equal(mockHandler.callCount, 0);
+
+  // Make a snapshot, as if an ad is loading
+  this.player.ads.snapshot = snapshot.getPlayerSnapshot(this.player);
+
+  // Check the snapshot exists and the handler was added
+  assert.ok(this.player.ads.snapshot);
+  assert.equal(this.player.ads._snapshotIOSTrackHandlerAdded, true, 'handler was added');
+  // Check the change handler is called
+  videojs.trigger(tracks, 'change');
+  assert.equal(mockHandler.callCount, 1);
+
+  // Restore the snapshot, as if an ad is finishing
+  snapshot.restorePlayerSnapshot(this.player, this.player.ads.snapshot);
+
+  // Check the snapshot is removed and the handler was removed
+  assert.ok(this.player.ads.snapshot, 'snapshot is left alone');
+  assert.equal(this.player.ads._snapshotIOSTrackHandlerAdded, false, 'handler was removed');
+  // Check the change handler is NOT called
+  videojs.trigger(tracks, 'change');
+  assert.equal(mockHandler.callCount, 1);
+
+  // Make another snapshot and confirm it is 
+  // removed when a new content source is loaded
+  this.player.ads.snapshot = snapshot.getPlayerSnapshot(this.player);
+  assert.ok(this.player.ads.snapshot);
+  assert.equal(this.player.ads._snapshotIOSTrackHandlerAdded, true, 'handler was added');
+  videojs.trigger(tracks, 'change');
+  assert.equal(mockHandler.callCount, 2);
+
+  this.player.trigger('contentupdate');
+
+  assert.ok(!this.player.ads.snapshot, 'snapshot is removed');
+  assert.equal(this.player.ads._snapshotIOSTrackHandlerAdded, false, 'handler was removed');
+
+  // Check the change handler is NOT called
+  videojs.trigger(tracks, 'change');
+  assert.equal(mockHandler.callCount, 2);
+
+  // Clean up
+  tracks.off('change', this.player.ads._trackChangeDuringSnapshotHandler);
+});
+
+if (videojs.browser.IS_IOS) {
+  QUnit.test('Check the trackChangeDuringSnapshotHandler takes effect on iOS', function(assert) {
+
+    // Since addTextTrack is async, wait for the addtrack event
+    this.player.textTracks().on('addtrack', function() {
+      // Confirm the track is added, set the mode to showing
+      assert.equal(this.player.textTracks().length, 1);
+      this.player.textTracks()[0].mode = 'showing';
+      assert.equal(this.player.textTracks()[0].mode, 'showing');
+
+      // Get the snapshot, make sure the mode is disabled now
+      this.player.ads.snapshot = snapshot.getPlayerSnapshot(this.player);
+      assert.equal(this.player.textTracks()[0].mode, 'disabled',
+        'snapshot sets tracks to disabled');
+
+      // Force the mode to showing
+      this.player.textTracks()[0].mode = 'showing';
+      videojs.trigger(this.player.textTracks(), 'change');
+      // Ad isn't playing so nothing will happen
+      assert.equal(this.player.textTracks()[0].mode, 'showing');
+
+      // Make it appear like an ad is playing and trigger change again
+      // the mode should go back to disabled
+      this.player.ads._inLinearAdMode = true;
+      videojs.trigger(this.player.textTracks(), 'change');
+      assert.equal(this.player.textTracks()[0].mode, 'disabled');
+    }.bind(this));
+
+    this.player.addTextTrack('captions', 'English', 'en');
+  });
+}


### PR DESCRIPTION
Changes include:

- now calls `snapshot. initializeSnapshot` when setting up the plugin
- now adds and removes the event handler to all platforms when creating/restoring a snapshot
- unit tests