### PR TITLE
remove android hack that was breaking videojs-ima

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "npm-run-all": "^4.0.2",
     "qunitjs": "^1.23.1",
     "rimraf": "^2.6.1",
-    "rollup": "^0.41.6",
+    "rollup": "^0.50",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-json": "^2.1.1",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -663,16 +663,6 @@ const contribAdsPlugin = function(options) {
           }
         },
         contentupdate() {
-          // We know sources have changed, so we call CancelContentPlay
-          // to avoid playback of video in the background of an ad. Playback Occurs on
-          // Android devices if we do not call cancelContentPlay. This is because
-          // the sources do not get updated in time on Android due to timing issues.
-          // So instead of checking if the sources have changed in the play handler
-          // and calling cancelContentPlay() there we call it here.
-          // This does not happen on Desktop as the sources do get updated in time.
-          if (!player.ads.shouldPlayContentBehindAd(player)) {
-            cancelContentPlay(player);
-          }
           if (player.paused()) {
             this.state = 'content-set';
           } else {


### PR DESCRIPTION
I researched the history of this code and found in a deleted comment that it was meant to address autoplay after source changes. I tested without this code in a variety of Android versions and found no issues. Further, [this code breaks videojs-ima](https://github.com/videojs/videojs-contrib-ads/issues/291). I believe it was a workaround for another bug that has since been fixed. Time to go.