### PR TITLE
fix: Captions showing during ads on desktop Safari 11

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -32,7 +32,6 @@ const removeNativePoster = function(player) {
   }
 };
 
-
 const DESKTOP_SAFARI_VERSION = (function() {
   const USER_AGENT = window.navigator && window.navigator.userAgent || '';
   const match = USER_AGENT.match(/Version\/(\d+)/);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -752,7 +752,7 @@ const contribAdsPlugin = function(options) {
     return !player.ads.shouldPlayContentBehindAd(player) &&
             player.ads.isAdPlaying() &&
             player.tech_.featuresNativeTextTracks &&
-            (videojs.browser.IS_IOS || DESKTOP_SAFARI_VERSION === 11) &&
+            (videojs.browser.IS_IOS || DESKTOP_SAFARI_VERSION >= 11) &&
             // older versions of video.js did not use an emulated textTrackList
             !Array.isArray(player.textTracks());
   };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -32,6 +32,17 @@ const removeNativePoster = function(player) {
   }
 };
 
+
+const DESKTOP_SAFARI_VERSION = (function() {
+  const USER_AGENT = window.navigator && window.navigator.userAgent || '';
+  const match = USER_AGENT.match(/Version\/(\d+)/);
+
+  if (match && match[1] && videojs.browser.IS_SAFARI && !videojs.browser.IS_IOS) {
+    return parseFloat(match[1]);
+  }
+  return null;
+}());
+
 // ---------------------------------------------------------------------------
 // Ad Framework
 // ---------------------------------------------------------------------------
@@ -742,7 +753,7 @@ const contribAdsPlugin = function(options) {
     return !player.ads.shouldPlayContentBehindAd(player) &&
             player.ads.isAdPlaying() &&
             player.tech_.featuresNativeTextTracks &&
-            videojs.browser.IS_IOS &&
+            (videojs.browser.IS_IOS || DESKTOP_SAFARI_VERSION === 11) &&
             // older versions of video.js did not use an emulated textTrackList
             !Array.isArray(player.textTracks());
   };


### PR DESCRIPTION
Fix for [BC-39385](https://jira.brightcove.com/browse/BC-39385).

## Description
We had previously observed and addressed [a problem on iOS](https://github.com/videojs/videojs-contrib-ads/pull/266) where Safari will sometimes forcibly enable text tracks by changing their mode to `showing`. At the time, that behavior only occurred on mobile, however, as of Safari 11 we now occasionally see the same thing on desktop.

## Solution
Change the scope of the existing solution for iOS to include desktop Safari 11.