### PR TITLE
Fix caption persistence

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -572,7 +572,7 @@ const contribAdsPlugin = function(options) {
     'postroll?': {
       enter() {
         player.ads._contentEnding = true;
-        
+
         if (player.ads.nopostroll_) {
           window.setTimeout(function() {
             // content-resuming happens after the timeout for backward-compatibility

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -572,7 +572,7 @@ const contribAdsPlugin = function(options) {
     'postroll?': {
       enter() {
         player.ads._contentEnding = true;
-        // this.snapshot = snapshot.getPlayerSnapshot(player);
+        
         if (player.ads.nopostroll_) {
           window.setTimeout(function() {
             // content-resuming happens after the timeout for backward-compatibility

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -572,7 +572,7 @@ const contribAdsPlugin = function(options) {
     'postroll?': {
       enter() {
         player.ads._contentEnding = true;
-        this.snapshot = snapshot.getPlayerSnapshot(player);
+        // this.snapshot = snapshot.getPlayerSnapshot(player);
         if (player.ads.nopostroll_) {
           window.setTimeout(function() {
             // content-resuming happens after the timeout for backward-compatibility

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -29,9 +29,7 @@ export function getPlayerSnapshot(player) {
   }
 
   const tech = player.$('.vjs-tech');
-  const remoteTracks = player.remoteTextTracks ? player.remoteTextTracks() : [];
   const tracks = player.textTracks ? player.textTracks() : [];
-  const suppressedRemoteTracks = [];
   const suppressedTracks = [];
   const snapshotObject = {
     ended: player.ended(),
@@ -45,17 +43,6 @@ export function getPlayerSnapshot(player) {
     snapshotObject.nativePoster = tech.poster;
     snapshotObject.style = tech.getAttribute('style');
   }
-
-  for (let i = 0; i < remoteTracks.length; i++) {
-    const track = remoteTracks[i];
-
-    suppressedRemoteTracks.push({
-      track,
-      mode: track.mode
-    });
-    track.mode = 'disabled';
-  }
-  snapshotObject.suppressedRemoteTracks = suppressedRemoteTracks;
 
   for (let i = 0; i < tracks.length; i++) {
     const track = tracks[i];
@@ -89,16 +76,10 @@ export function restorePlayerSnapshot(player, snapshotObject) {
   // the number of[ remaining attempts to restore the snapshot
   let attempts = 20;
 
-  const suppressedRemoteTracks = snapshotObject.suppressedRemoteTracks;
   const suppressedTracks = snapshotObject.suppressedTracks;
 
   let trackSnapshot;
   const restoreTracks = function() {
-    for (let i = 0; i < suppressedRemoteTracks.length; i++) {
-      trackSnapshot = suppressedRemoteTracks[i];
-      trackSnapshot.track.mode = trackSnapshot.mode;
-    }
-
     for (let i = 0; i < suppressedTracks.length; i++) {
       trackSnapshot = suppressedTracks[i];
       trackSnapshot.track.mode = trackSnapshot.mode;
@@ -222,11 +203,14 @@ export function restorePlayerSnapshot(player, snapshotObject) {
     // Reace the `canplay` event with a timeout.
     player.one('contentcanplay', tryToResume);
     player.ads.tryToResumeTimeout_ = player.setTimeout(tryToResume, 2000);
-  } else if (!player.ended() || !snapshotObject.ended) {
+  } else {
     // if we didn't change the src, just restore the tracks
     restoreTracks();
-    // the src didn't change and this wasn't a postroll
-    // just resume playback at the current time.
-    player.play();
+
+    if (!player.ended() || !snapshotObject.ended) {
+      // the src didn't change and this wasn't a postroll
+      // just resume playback at the current time.
+      player.play();
+    }
   }
 }

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -207,7 +207,9 @@ export function restorePlayerSnapshot(player, snapshotObject) {
     // if we didn't change the src, just restore the tracks
     restoreTracks();
 
-    if (!player.ended() || !snapshotObject.ended) {
+    // we don't need to check snapshotObject.ended here because the content video
+    // element wasn't recycled
+    if (!player.ended()) {
       // the src didn't change and this wasn't a postroll
       // just resume playback at the current time.
       player.play();

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -278,7 +278,7 @@ QUnit.test('"contentupdate" should fire when src is changed in "content-resuming
   this.player.trigger('adtimeout');
   this.player.trigger('ended');
   this.player.trigger('adtimeout');
-  this.player.ads.snapshot.ended = true;
+  // this.player.ads.snapshot.ended = true;
 
   // set src and trigger synthetic 'loadstart'
   this.player.src('http://media.w3.org/2010/05/sintel/trailer.mp4');
@@ -298,7 +298,7 @@ QUnit.test('"contentupdate" should fire when src is changed in "content-playback
   this.player.trigger('adtimeout');
   this.player.trigger('ended');
   this.player.trigger('adtimeout');
-  this.player.ads.snapshot.ended = true;
+  // this.player.ads.snapshot.ended = true;
   this.player.trigger('ended');
 
   // set src and trigger synthetic 'loadstart'
@@ -485,7 +485,7 @@ QUnit.test('adserror in postroll? transitions to content-playback and fires ende
   this.player.trigger('ended');
   assert.strictEqual(this.player.ads.state, 'postroll?');
 
-  this.player.ads.snapshot.ended = true;
+  // this.player.ads.snapshot.ended = true;
   this.player.trigger('adserror');
   assert.strictEqual(this.player.ads.state, 'content-resuming');
   assert.strictEqual(this.player.ads.triggerevent, 'adserror', 'adserror should be the trigger event');
@@ -506,7 +506,7 @@ QUnit.test('adtimeout in postroll? transitions to content-playback and fires end
   this.player.trigger('ended');
   assert.strictEqual(this.player.ads.state, 'postroll?');
 
-  this.player.ads.snapshot.ended = true;
+  // this.player.ads.snapshot.ended = true;
   this.player.trigger('adtimeout');
   assert.strictEqual(this.player.ads.state, 'content-resuming');
   assert.strictEqual(this.player.ads.triggerevent, 'adtimeout', 'adtimeout should be the trigger event');
@@ -527,7 +527,7 @@ QUnit.test('adskip in postroll? transitions to content-playback and fires ended'
   this.player.trigger('ended');
   assert.strictEqual(this.player.ads.state, 'postroll?');
 
-  this.player.ads.snapshot.ended = true;
+  // this.player.ads.snapshot.ended = true;
   this.player.trigger('adskip');
   assert.strictEqual(this.player.ads.state, 'content-resuming');
   assert.strictEqual(this.player.ads.triggerevent, 'adskip', 'adskip should be the trigger event');
@@ -553,7 +553,7 @@ QUnit.test('an "ended" event is fired in "content-resuming" via a timeout if not
   assert.strictEqual(this.player.ads.state, 'postroll?');
 
   this.player.ads.startLinearAdMode();
-  this.player.ads.snapshot.ended = true;
+  // this.player.ads.snapshot.ended = true;
   this.player.ads.endLinearAdMode();
   assert.strictEqual(this.player.ads.state, 'content-resuming');
   assert.strictEqual(endedSpy.callCount, 0, 'we should not have gotten an ended event yet');
@@ -579,7 +579,7 @@ QUnit.test('an "ended" event is not fired in "content-resuming" via a timeout if
   assert.strictEqual(this.player.ads.state, 'postroll?');
 
   this.player.ads.startLinearAdMode();
-  this.player.ads.snapshot.ended = true;
+  // this.player.ads.snapshot.ended = true;
   this.player.ads.endLinearAdMode();
   assert.strictEqual(this.player.ads.state, 'content-resuming');
   assert.strictEqual(endedSpy.callCount, 0, 'we should not have gotten an ended event yet');

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -278,7 +278,6 @@ QUnit.test('"contentupdate" should fire when src is changed in "content-resuming
   this.player.trigger('adtimeout');
   this.player.trigger('ended');
   this.player.trigger('adtimeout');
-  // this.player.ads.snapshot.ended = true;
 
   // set src and trigger synthetic 'loadstart'
   this.player.src('http://media.w3.org/2010/05/sintel/trailer.mp4');
@@ -298,7 +297,6 @@ QUnit.test('"contentupdate" should fire when src is changed in "content-playback
   this.player.trigger('adtimeout');
   this.player.trigger('ended');
   this.player.trigger('adtimeout');
-  // this.player.ads.snapshot.ended = true;
   this.player.trigger('ended');
 
   // set src and trigger synthetic 'loadstart'
@@ -485,7 +483,6 @@ QUnit.test('adserror in postroll? transitions to content-playback and fires ende
   this.player.trigger('ended');
   assert.strictEqual(this.player.ads.state, 'postroll?');
 
-  // this.player.ads.snapshot.ended = true;
   this.player.trigger('adserror');
   assert.strictEqual(this.player.ads.state, 'content-resuming');
   assert.strictEqual(this.player.ads.triggerevent, 'adserror', 'adserror should be the trigger event');
@@ -506,7 +503,6 @@ QUnit.test('adtimeout in postroll? transitions to content-playback and fires end
   this.player.trigger('ended');
   assert.strictEqual(this.player.ads.state, 'postroll?');
 
-  // this.player.ads.snapshot.ended = true;
   this.player.trigger('adtimeout');
   assert.strictEqual(this.player.ads.state, 'content-resuming');
   assert.strictEqual(this.player.ads.triggerevent, 'adtimeout', 'adtimeout should be the trigger event');
@@ -527,7 +523,6 @@ QUnit.test('adskip in postroll? transitions to content-playback and fires ended'
   this.player.trigger('ended');
   assert.strictEqual(this.player.ads.state, 'postroll?');
 
-  // this.player.ads.snapshot.ended = true;
   this.player.trigger('adskip');
   assert.strictEqual(this.player.ads.state, 'content-resuming');
   assert.strictEqual(this.player.ads.triggerevent, 'adskip', 'adskip should be the trigger event');
@@ -553,7 +548,6 @@ QUnit.test('an "ended" event is fired in "content-resuming" via a timeout if not
   assert.strictEqual(this.player.ads.state, 'postroll?');
 
   this.player.ads.startLinearAdMode();
-  // this.player.ads.snapshot.ended = true;
   this.player.ads.endLinearAdMode();
   assert.strictEqual(this.player.ads.state, 'content-resuming');
   assert.strictEqual(endedSpy.callCount, 0, 'we should not have gotten an ended event yet');
@@ -579,7 +573,6 @@ QUnit.test('an "ended" event is not fired in "content-resuming" via a timeout if
   assert.strictEqual(this.player.ads.state, 'postroll?');
 
   this.player.ads.startLinearAdMode();
-  // this.player.ads.snapshot.ended = true;
   this.player.ads.endLinearAdMode();
   assert.strictEqual(this.player.ads.state, 'content-resuming');
   assert.strictEqual(endedSpy.callCount, 0, 'we should not have gotten an ended event yet');

--- a/test/test.snapshot.js
+++ b/test/test.snapshot.js
@@ -295,7 +295,18 @@ QUnit.test('checks for a src attribute change that isn\'t reflected in currentSr
 });
 
 QUnit.test('When captions are enabled, the video\'s tracks will be disabled during the ad', function(assert) {
-  var tracks = this.player.remoteTextTracks ? this.player.remoteTextTracks() : [];
+  const trackSrc = 'http://solutions.brightcove.com/' +
+      'bcls/captions/adding_captions_to_videos_french.vtt';
+
+  // Add a text track
+  this.player.addRemoteTextTrack({
+    kind: 'captions',
+    language: 'fr',
+    label: 'French',
+    src: trackSrc
+  });
+
+  var tracks = this.player.textTracks ? this.player.textTracks() : [];
   var showing = 0;
   var disabled = 0;
   var i;
@@ -334,6 +345,7 @@ QUnit.test('When captions are enabled, the video\'s tracks will be disabled duri
   assert.strictEqual(disabled, tracks.length, 'all tracks should be disabled');
   this.player.ads.endLinearAdMode();
 
+  // Track mode should be restored after the ad ends
   for (i = 0; i < tracks.length; i++) {
     if (tracks[i].mode === 'showing') {
       showing++;
@@ -363,29 +375,11 @@ QUnit.test('Snapshot and text tracks', function(assert) {
     'bcls/captions/adding_captions_to_videos_french.vtt';
   const originalAddTrack = this.player.addTextTrack;
   const originalTextTracks = this.player.textTracks;
-  let mockTracks = [];
 
   // No text tracks at start
-  assert.equal(this.player.remoteTextTracks().length, 0);
   assert.equal(this.player.textTracks().length, 0);
 
-  // This is mocked because of native text track behavior
-  // which may not have the added track available immediately
-  this.player.addTextTrack = function(kind, label, language) {
-    mockTracks.push({
-      kind: kind,
-      label: label,
-      language: language,
-      mode: 'showing',
-      addEventListener: function() {},
-      removeEventListener: function() {}
-    });
-  }
-  this.player.textTracks = function() {
-    return mockTracks;
-  }
-  this.player.textTracks().addEventListener = function() {};
-  this.player.textTracks().removeEventListener = function() {};
+  this.player.addTextTrack('captions', 'Spanish', 'es');
 
   // Add a text track
   this.player.addRemoteTextTrack({
@@ -395,70 +389,63 @@ QUnit.test('Snapshot and text tracks', function(assert) {
     src: trackSrc
   });
 
-  this.player.addTextTrack('captions', 'Spanish', 'es');
-
-  // Show our new text track, since it's disabled by default
-  this.player.remoteTextTracks()[0].mode = 'showing';
-
+  // Make sure both track modes are 'showing', since it's 'disabled' by default
   this.player.textTracks()[0].mode = 'showing';
+  this.player.textTracks()[1].mode = 'showing';
 
   // Text track looks good
-  assert.equal(this.player.remoteTextTracks().length, 1);
-  assert.equal(this.player.remoteTextTrackEls().trackElements_[0].src, trackSrc);
-  assert.equal(this.player.remoteTextTracks()[0].kind, 'captions');
-  assert.equal(this.player.remoteTextTracks()[0].language, 'fr');
-  assert.equal(this.player.remoteTextTracks()[0].mode, 'showing');
-
-  assert.equal(this.player.textTracks().length, 1);
+  assert.equal(this.player.textTracks().length, 2);
   assert.equal(this.player.textTracks()[0].kind, 'captions');
   assert.equal(this.player.textTracks()[0].language, 'es');
   assert.equal(this.player.textTracks()[0].mode, 'showing');
+
+  assert.equal(this.player.remoteTextTrackEls().trackElements_[0].src, trackSrc);
+  assert.equal(this.player.textTracks()[1].kind, 'captions');
+  assert.equal(this.player.textTracks()[1].language, 'fr');
+  assert.equal(this.player.textTracks()[1].mode, 'showing');
 
   // Do a snapshot, as if an ad is starting
   this.player.ads.snapshot = snapshot.getPlayerSnapshot(this.player);
 
   // Snapshot reflects the text track
-  assert.equal(this.player.ads.snapshot.suppressedRemoteTracks.length, 1);
-  assert.equal(this.player.ads.snapshot.suppressedRemoteTracks[0].track.kind, 'captions');
-  assert.equal(this.player.ads.snapshot.suppressedRemoteTracks[0].track.language, 'fr');
-  assert.equal(this.player.ads.snapshot.suppressedRemoteTracks[0].mode, 'showing');
-
-  assert.equal(this.player.ads.snapshot.suppressedTracks.length, 1);
+  assert.equal(this.player.ads.snapshot.suppressedTracks.length, 2);
   assert.equal(this.player.ads.snapshot.suppressedTracks[0].track.kind, 'captions');
   assert.equal(this.player.ads.snapshot.suppressedTracks[0].track.language, 'es');
   assert.equal(this.player.ads.snapshot.suppressedTracks[0].mode, 'showing');
 
-  // Meanwhile, track is intact, just disabled
-  assert.equal(this.player.remoteTextTracks().length, 1);
-  assert.equal(this.player.remoteTextTrackEls().trackElements_[0].src, trackSrc);
-  assert.equal(this.player.remoteTextTracks()[0].kind, 'captions');
-  assert.equal(this.player.remoteTextTracks()[0].language, 'fr');
-  assert.equal(this.player.remoteTextTracks()[0].mode, 'disabled');
+  assert.equal(this.player.ads.snapshot.suppressedTracks[1].track.kind, 'captions');
+  assert.equal(this.player.ads.snapshot.suppressedTracks[1].track.language, 'fr');
+  assert.equal(this.player.ads.snapshot.suppressedTracks[1].mode, 'showing');
 
-  assert.equal(this.player.textTracks().length, 1);
+  // Meanwhile, track is intact, just disabled
+  assert.equal(this.player.textTracks().length, 2);
   assert.equal(this.player.textTracks()[0].kind, 'captions');
   assert.equal(this.player.textTracks()[0].language, 'es');
   assert.equal(this.player.textTracks()[0].mode, 'disabled');
 
+  assert.equal(this.player.remoteTextTrackEls().trackElements_[0].src, trackSrc);
+  assert.equal(this.player.textTracks()[1].kind, 'captions');
+  assert.equal(this.player.textTracks()[1].language, 'fr');
+  assert.equal(this.player.textTracks()[1].mode, 'disabled');
+
   // Double check that the track remains disabled after 3s
   this.clock.tick(3000);
-  assert.equal(this.player.remoteTextTracks()[0].mode, 'disabled');
   assert.equal(this.player.textTracks()[0].mode, 'disabled');
+  assert.equal(this.player.textTracks()[1].mode, 'disabled');
 
   // Restore the snapshot, as if an ad is ending
   snapshot.restorePlayerSnapshot(this.player, this.player.ads.snapshot);
 
   // Everything is back to normal
-  assert.equal(this.player.remoteTextTracks().length, 1);
-  assert.equal(this.player.remoteTextTrackEls().trackElements_[0].src, trackSrc);
-  assert.equal(this.player.remoteTextTracks()[0].kind, 'captions');
-  assert.equal(this.player.remoteTextTracks()[0].language, 'fr');
-  assert.equal(this.player.remoteTextTracks()[0].mode, 'showing');
-
-  assert.equal(this.player.textTracks().length, 1);
+  assert.equal(this.player.textTracks().length, 2);
   assert.equal(this.player.textTracks()[0].kind, 'captions');
   assert.equal(this.player.textTracks()[0].language, 'es');
   assert.equal(this.player.textTracks()[0].mode, 'showing');
+  
+  assert.equal(this.player.remoteTextTrackEls().trackElements_[0].src, trackSrc);
+  assert.equal(this.player.textTracks()[1].kind, 'captions');
+  assert.equal(this.player.textTracks()[1].language, 'fr');
+  assert.equal(this.player.textTracks()[1].mode, 'showing');
 
   // Resetting mocked methods
   this.player.addTextTrack = originalAddTrack;


### PR DESCRIPTION
Proposed fix for [BC-38559](https://jira.brightcove.com/browse/BC-38559) and [BC-39463](https://jira.brightcove.com/browse/BC-39463).

## Description
There are 3 issues this PR addresses:

1. Text track modes are not correctly restored after ads in general. This is the result of the fact that the snapshot saves and restores both `player.textTracks()` and `player.remoteTextTracks()` separately. `player.textTracks()` contains the TextTrackList of all text tracks, so it isn't necessary to also get a snapshot of `remoteTextTracks()`. And since they both store references to the same remote text tracks, there's a bug in [this logic](https://github.com/videojs/videojs-contrib-ads/blob/master/src/snapshot.js#L49-L69) where the remote text track modes are all disabled before the second loop, so the snapshot saves and restores them as such.

2. There is also a separate (but related) issue where `restorePlayerSnapshot()` [doesn't restore text track modes](https://github.com/videojs/videojs-contrib-ads/blob/master/src/snapshot.js#L225-L227) after a postroll ad. This means that caption preference will not persist through multiple videos in a playlist.

3. If there isn't a postroll, caption preference still will not persist through videos in a playlist because the snapshot taken in the `postroll?` state disables all track modes and they are never restored.

## Specific changes
1. Remove `postroll?` snapshot
2. Modify conditional in `restorePlayerSnapshot()` to restore text track modes after postroll ads
3. Only save and restore `player.textTracks()`, no need to snapshot `remoteTextTracks()`
4. Make necessary modifications to tests (also addressed an issue I discovered where [this test](https://github.com/videojs/videojs-contrib-ads/blob/master/test/test.snapshot.js#L297) seems to never fail because `tracks` is always an array with length 0.)