### PR TITLE
Fix: content can play too early after contentupdate

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -436,9 +436,6 @@ const contribAdsPlugin = function(options) {
         },
         nopreroll() {
           this.state = 'content-playback';
-        },
-        contentupdate() {
-          this.state = 'content-set';
         }
       }
     },

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -729,6 +729,34 @@ QUnit.test('adsready in content-playback triggers readyforpreroll', function(ass
   assert.strictEqual(spy.getCall(0).args[0].type, 'readyforpreroll', 'readyforpreroll should have been triggered.');
 });
 
+QUnit.test('contentupdate in content-playback transitions to content-set if the player is paused', function(assert) {
+  assert.expect(2);
+
+  this.player.trigger('play');
+  this.player.trigger('adtimeout');
+  assert.strictEqual(this.player.ads.state, 'content-playback');
+  this.player.paused = function() {
+    return true;
+  };
+  this.player.trigger('contentupdate');
+  assert.strictEqual(this.player.ads.state, 'content-set');
+});
+
+QUnit.test('contentupdate in content-playback pauses player and transitions to ads-ready? if the player is not paused', function(assert) {
+  assert.expect(3);
+
+  this.player.trigger('play');
+  this.player.trigger('adtimeout');
+  assert.strictEqual(this.player.ads.state, 'content-playback');
+  this.player.paused = function() {
+    return false;
+  };
+  sinon.spy(this.player, 'pause');
+  this.player.trigger('contentupdate');
+  assert.strictEqual(this.player.ads.state, 'ads-ready?');
+  assert.ok(this.player.pause.calledOnce, 'player was paused');
+});
+
 // ----------------------------------
 // Event prefixing during ad playback
 // ----------------------------------

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -729,6 +729,16 @@ QUnit.test('adsready in content-playback triggers readyforpreroll', function(ass
   assert.strictEqual(spy.getCall(0).args[0].type, 'readyforpreroll', 'readyforpreroll should have been triggered.');
 });
 
+QUnit.test('contentupdate in preroll? transitions to content-set', function(assert) {
+  assert.expect(2);
+
+  this.player.trigger('play');
+  this.player.trigger('adsready');
+  assert.strictEqual(this.player.ads.state, 'preroll?');
+  this.player.trigger('contentupdate');
+  assert.strictEqual(this.player.ads.state, 'content-set');
+});
+
 QUnit.test('contentupdate in content-playback transitions to content-set if the player is paused', function(assert) {
   assert.expect(2);
 
@@ -743,7 +753,7 @@ QUnit.test('contentupdate in content-playback transitions to content-set if the 
 });
 
 QUnit.test('contentupdate in content-playback pauses player and transitions to ads-ready? if the player is not paused', function(assert) {
-  assert.expect(3);
+  assert.expect(4);
 
   this.player.trigger('play');
   this.player.trigger('adtimeout');
@@ -755,6 +765,7 @@ QUnit.test('contentupdate in content-playback pauses player and transitions to a
   this.player.trigger('contentupdate');
   assert.strictEqual(this.player.ads.state, 'ads-ready?');
   assert.ok(this.player.pause.calledOnce, 'player was paused');
+  assert.ok(this.player.ads._pausedOnContentupdate, '_pausedOnContentupdate is true');
 });
 
 // ----------------------------------

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -729,42 +729,16 @@ QUnit.test('adsready in content-playback triggers readyforpreroll', function(ass
   assert.strictEqual(spy.getCall(0).args[0].type, 'readyforpreroll', 'readyforpreroll should have been triggered.');
 });
 
-QUnit.test('contentupdate in preroll? transitions to content-set', function(assert) {
-  assert.expect(2);
-
-  this.player.trigger('loadstart');
-  this.player.trigger('play');
-  this.player.trigger('adsready');
-  assert.strictEqual(this.player.ads.state, 'preroll?');
-  this.player.trigger('contentupdate');
-  assert.strictEqual(this.player.ads.state, 'content-set');
-});
-
-QUnit.test('contentupdate in content-playback transitions to content-set if the player is paused', function(assert) {
-  assert.expect(2);
-
-  this.player.trigger('loadstart');
-  this.player.ads.skipLinearAdMode();
-  assert.strictEqual(this.player.ads.state, 'content-playback');
-  this.player.paused = function() {
-    return true;
-  };
-  this.player.trigger('contentupdate');
-  assert.strictEqual(this.player.ads.state, 'content-set');
-});
-
 QUnit.test('contentupdate in content-playback transitions to ads-ready? and pauses player if not already paused', function(assert) {
   assert.expect(4);
 
   this.player.trigger('loadstart');
   this.player.ads.skipLinearAdMode();
-  assert.strictEqual(this.player.ads.state, 'content-playback');
   this.player.paused = function() {
     return false;
   };
   sinon.spy(this.player, 'pause');
   this.player.trigger('contentupdate');
-  assert.strictEqual(this.player.ads.state, 'ads-ready?');
   assert.ok(this.player.pause.calledOnce, 'player was paused');
   assert.ok(this.player.ads._pausedOnContentupdate, '_pausedOnContentupdate is true');
 });

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -730,8 +730,6 @@ QUnit.test('adsready in content-playback triggers readyforpreroll', function(ass
 });
 
 QUnit.test('contentupdate in content-playback transitions to ads-ready? and pauses player if not already paused', function(assert) {
-  assert.expect(4);
-
   this.player.trigger('loadstart');
   this.player.ads.skipLinearAdMode();
   this.player.paused = function() {

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -752,7 +752,7 @@ QUnit.test('contentupdate in content-playback transitions to content-set if the 
   assert.strictEqual(this.player.ads.state, 'content-set');
 });
 
-QUnit.test('contentupdate in content-playback pauses player and transitions to ads-ready? if the player is not paused', function(assert) {
+QUnit.test('contentupdate in content-playback transitions to ads-ready? and pauses player if not already paused', function(assert) {
   assert.expect(4);
 
   this.player.trigger('play');

--- a/test/test.ads.js
+++ b/test/test.ads.js
@@ -732,6 +732,7 @@ QUnit.test('adsready in content-playback triggers readyforpreroll', function(ass
 QUnit.test('contentupdate in preroll? transitions to content-set', function(assert) {
   assert.expect(2);
 
+  this.player.trigger('loadstart');
   this.player.trigger('play');
   this.player.trigger('adsready');
   assert.strictEqual(this.player.ads.state, 'preroll?');
@@ -742,8 +743,8 @@ QUnit.test('contentupdate in preroll? transitions to content-set', function(asse
 QUnit.test('contentupdate in content-playback transitions to content-set if the player is paused', function(assert) {
   assert.expect(2);
 
-  this.player.trigger('play');
-  this.player.trigger('adtimeout');
+  this.player.trigger('loadstart');
+  this.player.ads.skipLinearAdMode();
   assert.strictEqual(this.player.ads.state, 'content-playback');
   this.player.paused = function() {
     return true;
@@ -755,8 +756,8 @@ QUnit.test('contentupdate in content-playback transitions to content-set if the 
 QUnit.test('contentupdate in content-playback transitions to ads-ready? and pauses player if not already paused', function(assert) {
   assert.expect(4);
 
-  this.player.trigger('play');
-  this.player.trigger('adtimeout');
+  this.player.trigger('loadstart');
+  this.player.ads.skipLinearAdMode();
   assert.strictEqual(this.player.ads.state, 'content-playback');
   this.player.paused = function() {
     return false;


### PR DESCRIPTION
## Description

This addresses a couple of issues surrounding contentupdates:

1.  Content can start playing immediately after a source change because we don't proactively pause the player if it is playing following a `contentupdate`
2. There is no `contentupdate` event handler in the 'preroll?' state, so if one occurs we remain in ‘preroll?’ through the source change. And because the ad [timeout](https://github.com/videojs/videojs-contrib-ads/blob/master/src/plugin.js#L397-L399) isn’t cleared, the eventual `adtimeout` event causes a transition directly into ‘content-playback’, bypassing 'content-set' / 'ads-ready?' / 'ads-ready'

**EDIT: We are going to wait to address no.2 in the upcoming refactor**

## Specific Additions

1. If we are in 'content-playback' and a `contentupdate` occurs, pause the player if it is not already paused. 
2. Add a `contentupdate()` handler in 'preroll?' that changes state to 'content-set'

**As mentioned above: we'll hold off on no.2 until the refactor**