### PR TITLE
Play middleware: only trigger play event when our play middleware terminates

### DIFF
--- a/src/playMiddleware.js
+++ b/src/playMiddleware.js
@@ -39,11 +39,12 @@ obj.playMiddleware = function(player) {
       // ad supported player
       if (player.ads && player.ads._shouldBlockPlay === true) {
         player.ads.debug('Using playMiddleware to block content playback');
+        player.ads._playBlocked = true;
         return videojsReference.middleware.TERMINATOR;
       }
     },
     play(terminated, value) {
-      if (player.ads && terminated) {
+      if (player.ads && player.ads._playBlocked && terminated) {
         player.ads.debug('Play call to Tech was terminated.');
         // Trigger play event to match the user's intent to play.
         // The call to play on the Tech has been blocked, so triggering
@@ -51,6 +52,8 @@ obj.playMiddleware = function(player) {
         player.trigger('play');
         // At this point the player has technically started
         player.addClass('vjs-has-started');
+        // Reset playBlocked
+        player.ads._playBlocked = false;
       }
     }
   };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -193,7 +193,7 @@ const contribAdsPlugin = function(options) {
 
     // Should we block calls to play on the content player?
     _shouldBlockPlay: false,
-    // Was play blocked by the plugin?
+    // Was play blocked by the plugin's playMiddleware feature?
     _playBlocked: false,
     // Tracks whether play has been requested for this source,
     // either by the play method or user interaction

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -193,6 +193,8 @@ const contribAdsPlugin = function(options) {
 
     // Should we block calls to play on the content player?
     _shouldBlockPlay: false,
+    // Was play blocked by the plugin?
+    _playBlocked: false,
     // Tracks whether play has been requested for this source,
     // either by the play method or user interaction
     _playRequested: false,
@@ -213,6 +215,7 @@ const contribAdsPlugin = function(options) {
       player.ads._hasThereBeenALoadedMetaData = false;
       player.ads._cancelledPlay = false;
       player.ads._shouldBlockPlay = false;
+      player.ads._playBlocked = false;
       player.ads.nopreroll_ = false;
       player.ads.nopostroll_ = false;
       player.ads._playRequested = false;

--- a/test/integration/test.playMiddleware.js
+++ b/test/integration/test.playMiddleware.js
@@ -195,7 +195,7 @@ QUnit.test("don't trigger play event if another middleware terminates", function
     assert.strictEqual(playSpy.callCount, 0,
       'play event should not be triggered');
     done();
-  }, 200);
+  }, 1);
 
   localPlayer.src({
     src: 'http://vjs.zencdn.net/v/oceans.webm',


### PR DESCRIPTION
This ensures that the code in playMiddleware.play does not run if another middleware terminates.