### PR TITLE
IMA content flash after preroll  - preload none (onload)

### DIFF
--- a/docs/integrator/snapshot.md
+++ b/docs/integrator/snapshot.md
@@ -4,6 +4,5 @@ The snapshot feature records the player state when an ad break begins and restor
 
 * Content source
 * Current time
-* Poster image
 * Style attribute
 * Text tracks

--- a/src/adBreak.js
+++ b/src/adBreak.js
@@ -36,8 +36,7 @@ function start(player) {
   }
 
   // This removes the native poster so the ads don't show the content
-  // poster if content element is reused for ad playback. The snapshot
-  // will restore it afterwards.
+  // poster if content element is reused for ad playback.
   player.ads.removeNativePoster();
 }
 

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -38,7 +38,6 @@ export function getPlayerSnapshot(player) {
   };
 
   if (tech) {
-    snapshotObject.nativePoster = tech.poster;
     snapshotObject.style = tech.getAttribute('style');
   }
 

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -178,10 +178,6 @@ export function restorePlayerSnapshot(player, snapshotObject, callback) {
     }
   };
 
-  if (snapshotObject.nativePoster) {
-    tech.poster = snapshotObject.nativePoster;
-  }
-
   if ('style' in snapshotObject) {
     // overwrite all css style properties to restore state precisely
     tech.setAttribute('style', snapshotObject.style || '');

--- a/src/states/Preroll.js
+++ b/src/states/Preroll.js
@@ -182,6 +182,9 @@ export default class Preroll extends AdState {
       player.removeClass('vjs-ad-loading');
       player.addClass('vjs-ad-content-resuming');
       adBreak.end(player);
+
+      // Removes the native poster avoiding content flash after preroll
+      player.ads.removeNativePoster();
       this.contentResuming = true;
     }
   }

--- a/src/states/Preroll.js
+++ b/src/states/Preroll.js
@@ -182,9 +182,6 @@ export default class Preroll extends AdState {
       player.removeClass('vjs-ad-loading');
       player.addClass('vjs-ad-content-resuming');
       adBreak.end(player);
-
-      // Removes the native poster avoiding content flash after preroll
-      player.ads.removeNativePoster();
       this.contentResuming = true;
     }
   }

--- a/test/integration/test.ads.js
+++ b/test/integration/test.ads.js
@@ -135,17 +135,6 @@ QUnit.test('removes the poster attribute so it does not flash between videos', f
   assert.strictEqual(this.video.poster, '', 'poster is removed');
 });
 
-QUnit.test('restores the poster attribute after ads have ended', function(assert) {
-  this.video.poster = 'http://www.videojs.com/img/poster.jpg';
-  this.player.trigger('adsready');
-  this.player.trigger('play');
-  this.player.ads.startLinearAdMode();
-  this.player.ads.endLinearAdMode();
-  assert.ok(this.video.poster, 'the poster is restored');
-
-  this.player.trigger('playing');
-});
-
 QUnit.test('changing the src triggers "contentupdate"', function(assert) {
   var spy = sinon.spy();
 


### PR DESCRIPTION
When `startLinearAdMode()` is invoked, ad break starts where `removeNativePoster()` removes the poster attribute. When the ad break ends, `endLinearAdMode()` is invoked and adBreak.end(player) is called. Here, it restores the snapshot [restorePlayerSnapshot](https://github.com/videojs/videojs-contrib-ads/blob/c1f23c74f35702314b82e4d1468d29efad08dcdc/src/adBreak.js#L69) and adds the poster attribute [here](https://github.com/videojs/videojs-contrib-ads/blob/c1f23c74f35702314b82e4d1468d29efad08dcdc/src/snapshot.js#L182). Also, in videojs-ima3, it listens to the `playing` event and once again removes the poster attribute.
What happens in case of `preload:none` is, before it listens to `playing` and removes the poster attribute; there is already a flash of content(poster) as the poster attribute was added while restoring the snapshot.
Proposal: Do not add the `poster` attribute back when the ad break ends (as we are again removing it in videojs-ima3 once `playing` is triggered) 