### PR TITLE
feat: Allow default values for macros

### DIFF
--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -58,3 +58,7 @@ A macro such as {pageVariable.foobar} allows the user access the value of any pr
 | Null      | Returns the string `"null"`           |
 | Undefined | Logs warning and returns empty string |
 | Other     | Logs warning and returns empty string |
+
+## Default values in macros
+
+A default value can be provided within a macro, in which case this value will be used where not resolvable e.g. `http://example.com/ad/{pageVariable.adConf=1234}` becomes `http://example.com/ad/1234` if `window.adConf` is undefined.

--- a/src/macros.js
+++ b/src/macros.js
@@ -84,13 +84,6 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
   customFields(this.mediainfo, macros, 'custom_fields');
   customFields(this.mediainfo, macros, 'customFields');
 
-  // Set any defaults for undefined custom fields
-  Object.keys(defaults).filter(function(m) {
-    return (m.substr(0, 17) === '{mediainfo.custom' && typeof macros[m] === 'undefined');
-  }).forEach(function(m) {
-    macros[m] = defaults[m];
-  });
-
   // Go through all the replacement macros and apply them to the string.
   // This will replace all occurrences of the replacement macros.
   for (const i in macros) {
@@ -113,17 +106,15 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
       }
     }
 
-    // Use default if provided
-    if (typeof value === 'undefined' && defaults[`{pageVariable.${name}}`]) {
-      value = defaults[`{pageVariable.${name}}`];
-    }
-
     const type = typeof value;
 
     // Only allow certain types of values. Anything else is probably a mistake.
     if (value === null) {
       return 'null';
     } else if (value === undefined) {
+      if (defaults[`{pageVariable.${name}}`]) {
+        return defaults[`{pageVariable.${name}}`];
+      }
       videojs.log.warn(`Page variable "${name}" not found`);
       return '';
     } else if (type !== 'string' && type !== 'number' && type !== 'boolean') {
@@ -133,6 +124,11 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
 
     return uriEncodeIfNeeded(String(value), uriEncode);
   });
+
+  // Replace defaults
+  for (const defaultVal in defaults) {
+    string = string.replace(defaultVal, defaults[defaultVal]);
+  }
 
   return string;
 }

--- a/test/integration/test.macros.js
+++ b/test/integration/test.macros.js
@@ -158,3 +158,48 @@ QUnit.test('customMacros', function(assert) {
 
   assert.equal(result, 'The sky is blue. Hooray!');
 });
+
+QUnit.test('default values', function(assert) {
+  this.player.mediainfo = {
+    customFields: {
+      set: 1
+    },
+    reference_id: 'abc'
+  };
+  window.testvar1 = 'a';
+
+  assert.equal(
+    this.player.ads.adMacroReplacement('{mediainfo.customFields.set=other}'), '1',
+    'custom fields: set value is not replaced by default'
+  );
+
+  assert.equal(
+    this.player.ads.adMacroReplacement('{mediainfo.customFields.unsset=2}'), '2',
+    'custom fields: unset value is replaced by default'
+  );
+
+  assert.equal(
+    this.player.ads.adMacroReplacement('{mediainfo.ad_keys=key=value}'), 'key=value',
+    'equals in default value preserved'
+  );
+
+  assert.equal(
+    this.player.ads.adMacroReplacement('{mediainfo.reference_id=Other}'), 'abc',
+    'mediainfo: set value is not replaced by default'
+  );
+
+  assert.equal(
+    this.player.ads.adMacroReplacement('{mediainfo.description=xyz}'), 'xyz',
+    'mediainfo: unset value is replaced by default'
+  );
+
+  assert.equal(
+    this.player.ads.adMacroReplacement('{pageVariable.testvar1=b}'), 'a',
+    'pageVariable: set value is not replaced by default'
+  );
+
+  assert.equal(
+    this.player.ads.adMacroReplacement('{pageVariable.testvar2=c}'), 'c',
+    'pageVariable: unset value is replaced by default'
+  );
+});


### PR DESCRIPTION
For use cases where an unresolved macro should be replaced with a default value rather than `''` for the ad tag to be valid, this change allows a default to be set.

Syntax is `{pageVariable.myVar=xyz}`, which will be replaced by `window.myVar` as before if that is defined, otherwise `'xyz'`