### PR TITLE
Warnings instead of errors if play promise rejected

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -126,7 +126,13 @@ const contribAdsPlugin = function(options) {
       return;
     }
 
-    player.play();
+    const playPromise = player.play();
+
+    if (playPromise) {
+      playPromise.catch((error) => {
+        videojs.log.warn('Play promise rejected when playing ad', error);
+      });
+    }
   });
 
   player.on('nopreroll', function() {


### PR DESCRIPTION
This doesn't seem to happen in practice, but it was causing tests to fail. This may have to do with tests not being cleaned up properly, but this makes the tests pass for now.