### PR TITLE
set contentresuming before calling adBreak.end

### DIFF
--- a/src/states/Preroll.js
+++ b/src/states/Preroll.js
@@ -181,8 +181,8 @@ export default class Preroll extends AdState {
     if (this.inAdBreak()) {
       player.removeClass('vjs-ad-loading');
       player.addClass('vjs-ad-content-resuming');
-      adBreak.end(player);
       this.contentResuming = true;
+      adBreak.end(player);
     }
   }
 


### PR DESCRIPTION
On IE11, we can potentially receive a `play` event before `adBreak.end()` completes and thus before we set  `this.contentResuming = true;`.  This results in that `play` event being prefixed as an `ad-play` event since `contentResuming` is still `false` until after `end` completes.

This fix simply moves `this.contentResuming = true;` above the `AdBreak.end()` call which is in line with what we are also doing in `Midroll.js`.

Logically, this makes sense because we are adding the`vjs-ad-content-resuming` class to the player as a signal to the UI that we are done playing ads.

Tested on IE11 on Win7 and on Mac OS X Chrome 67.