### PR TITLE
check shouldPlayContentBehindAd for live only

### DIFF
--- a/src/ads.js
+++ b/src/ads.js
@@ -131,12 +131,15 @@ export default function getAds(player) {
     // This is only done during live streams on platforms where it's supported.
     // This improves speed and accuracy when returning from an ad break.
     shouldPlayContentBehindAd(somePlayer) {
-      if (this.settings.liveCuePoints === false) {
+      if (!somePlayer) {
+        throw new Error('shouldPlayContentBehindAd requires a player as a param');
+      } else if (!somePlayer.ads.settings.liveCuePoints) {
         return false;
+      } else {
+        return !videojs.browser.IS_IOS &&
+               !videojs.browser.IS_ANDROID &&
+               somePlayer.duration() === Infinity;
       }
-      return !videojs.browser.IS_IOS &&
-             !videojs.browser.IS_ANDROID &&
-             somePlayer.duration() === Infinity;
     },
 
     // Returns true if player is in ad mode.

--- a/test/integration/test.ads.js
+++ b/test/integration/test.ads.js
@@ -811,6 +811,21 @@ QUnit.test('shouldPlayContentBehindAd', function(assert) {
   videojs.browser.IS_ANDROID = false;
   assert.strictEqual(this.player.ads.shouldPlayContentBehindAd(this.player), false);
 
+  this.player.duration = function() {return Infinity;};
+  videojs.browser.IS_IOS = false;
+  videojs.browser.IS_ANDROID = false;
+  try {
+    this.player.ads.shouldPlayContentBehindAd();
+  } catch (error) {
+    assert.strictEqual(error.message,
+      'shouldPlayContentBehindAd requires a player as a param');
+  }
+
+  this.player.duration = function() {return Infinity;};
+  videojs.browser.IS_IOS = false;
+  videojs.browser.IS_ANDROID = false;
+  this.player.ads.settings.liveCuePoints = false;
+  assert.strictEqual(this.player.ads.shouldPlayContentBehindAd(this.player), false);
 });
 
 QUnit.test('Check incorrect addition of vjs-live during ad-playback', function(assert) {


### PR DESCRIPTION
Make sure `shouldPlayContentBehindAd` only returns `true` for liveCuePoints