### PR TITLE
chore: Remove unneeded onDispose handling

### DIFF
--- a/src/states/BeforePreroll.js
+++ b/src/states/BeforePreroll.js
@@ -90,8 +90,4 @@ export default class BeforePreroll extends ContentState {
     this.onPlay(this.player);
   }
 
-  onDispose() {
-    this.init(this.player);
-  }
-
 }

--- a/src/states/abstract/State.js
+++ b/src/states/abstract/State.js
@@ -54,7 +54,6 @@ export default class State {
   onAdTimeout() {}
   onAdStarted() {}
   onContentChanged() {}
-  onDispose() {}
   onContentResumed() {}
   onReadyForPostroll() {
     videojs.log.warn('Unexpected readyforpostroll event');
@@ -124,8 +123,6 @@ export default class State {
       this.onAdStarted(player);
     } else if (type === 'contentchanged') {
       this.onContentChanged(player);
-    } else if (type === 'dispose') {
-      this.onDispose(player);
     } else if (type === 'contentresumed') {
       this.onContentResumed(player);
     } else if (type === 'readyforpostroll') {

--- a/test/unit/states/test.BeforePreroll.js
+++ b/test/unit/states/test.BeforePreroll.js
@@ -102,12 +102,6 @@ QUnit.test('handles content change', function(assert) {
   assert.equal(this.beforePreroll.onPlay.calledOnce, true);
 });
 
-QUnit.test('handles dispose', function(assert) {
-  sinon.spy(this.beforePreroll, "init");
-  this.beforePreroll.onDispose(this.player);
-  assert.equal(this.beforePreroll.init.calledOnce, true);
-});
-
 QUnit.test('sets _shouldBlockPlay to true', function(assert) {
   this.beforePreroll.init(this.player);
   assert.equal(this.player.ads._shouldBlockPlay, true);


### PR DESCRIPTION
This isn't necessary because on dispose the plugin is abandoned. It's state doesn't matter anymore because it won't be used. Any new players will have newly-initialized plugins with their initial state set correctly.