### PR TITLE
fix: Middleware log message

### DIFF
--- a/src/cancelContentPlay.js
+++ b/src/cancelContentPlay.js
@@ -2,7 +2,7 @@ import videojs from 'video.js';
 
 export default function initCancelContentPlay(player, debug) {
   if (debug) {
-    videojs.log('ADS:', 'Using cancelContentPlay to block content playback');
+    videojs.log('Using cancelContentPlay to block content playback');
   }
 
   // Listen to play events to "cancel" them afterward

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -83,11 +83,7 @@ const contribAdsPlugin = function(options) {
   // will disallow calling play once play blocking is lifted)
   // The middleware must also be registered outside of the plugin,
   // to avoid a middleware factory being created for each player
-  if (isMiddlewareMediatorSupported() && settings.debug) {
-    // We log the debug message here as the plugin settings are available here
-    videojs.log('ADS:', 'Play middleware has been registered with videojs');
-  } else {
-    // Register the cancelContentPlay feature on the player
+  if (!isMiddlewareMediatorSupported()) {
     initCancelContentPlay(player, settings.debug);
   }
 

--- a/src/register.js
+++ b/src/register.js
@@ -64,6 +64,7 @@ function register(contribAdsPlugin) {
     // Register the play middleware
     videojs.use('*', playMiddleware);
     videojs.usingContribAdsMiddleware_ = true;
+    videojs.log('Play middleware has been registered with videojs');
   }
 
   return true;


### PR DESCRIPTION
Fixes a bug where the "registered middleware" log message would trigger after dispose/reinit even though middleware is not reregistered in this case.

Also fixes a bug where `initCancelContentPlay` would always be called if the debug setting was false. Not sure if this had functional consequences but it's clearly unintended.