### PR TITLE
fix: Remove hack in beforepreroll contentchanged handling

### DIFF
--- a/src/states/BeforePreroll.js
+++ b/src/states/BeforePreroll.js
@@ -85,9 +85,6 @@ export default class BeforePreroll extends ContentState {
 
   onContentChanged() {
     this.init(this.player);
-
-    // TODO: Handle case where player does not play on content change
-    this.onPlay(this.player);
   }
 
   onDispose() {

--- a/test/unit/states/test.BeforePreroll.js
+++ b/test/unit/states/test.BeforePreroll.js
@@ -96,10 +96,8 @@ QUnit.test('skips the preroll', function(assert) {
 
 QUnit.test('handles content change', function(assert) {
   sinon.spy(this.beforePreroll, "init");
-  sinon.spy(this.beforePreroll, "onPlay");
   this.beforePreroll.onContentChanged(this.player);
   assert.equal(this.beforePreroll.init.calledOnce, true);
-  assert.equal(this.beforePreroll.onPlay.calledOnce, true);
 });
 
 QUnit.test('handles dispose', function(assert) {


### PR DESCRIPTION
I thought this was needed, but it turned out to workaround a bug in my integration. Cleaning up the upstream.