### PR TITLE
refactor: Add internal registration system for states to work around circular dependency issues.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,7 +16,18 @@ import initCancelContentPlay from './cancelContentPlay.js';
 import playMiddlewareFeature from './playMiddleware.js';
 import register from './register.js';
 
-import {BeforePreroll, StitchedContentPlayback} from './states.js';
+import States from './states.js';
+import './states/abstract/State.js';
+import './states/abstract/AdState.js';
+import './states/abstract/ContentState.js';
+import './states/AdsDone.js';
+import './states/Preroll.js';
+import './states/BeforePreroll.js';
+import './states/Midroll.js';
+import './states/Postroll.js';
+import './states/ContentPlayback.js';
+import './states/StitchedContentPlayback.js';
+import './states/StitchedAdRoll.js';
 
 const { isMiddlewareMediatorSupported } = playMiddlewareFeature;
 const VIDEO_EVENTS = videojs.getTech('Html5').Events;
@@ -185,9 +196,9 @@ const contribAdsPlugin = function(options) {
   settings.stitchedAds = !!settings.stitchedAds;
 
   if (settings.stitchedAds) {
-    player.ads._state = new StitchedContentPlayback(player);
+    player.ads._state = new (States.getState('StitchedContentPlayback'))(player);
   } else {
-    player.ads._state = new BeforePreroll(player);
+    player.ads._state = new (States.getState('BeforePreroll'))(player);
   }
 
   player.ads._state.init(player);

--- a/src/states.js
+++ b/src/states.js
@@ -1,29 +1,25 @@
-/*
- * This file is necessary to avoid this rollup issue:
- * https://github.com/rollup/rollup/issues/1089
- */
-import State from './states/abstract/State.js';
-import AdState from './states/abstract/AdState.js';
-import ContentState from './states/abstract/ContentState.js';
-import Preroll from './states/Preroll.js';
-import Midroll from './states/Midroll.js';
-import Postroll from './states/Postroll.js';
-import BeforePreroll from './states/BeforePreroll.js';
-import ContentPlayback from './states/ContentPlayback.js';
-import AdsDone from './states/AdsDone.js';
-import StitchedAdRoll from './states/StitchedAdRoll.js';
-import StitchedContentPlayback from './states/StitchedContentPlayback.js';
+export default class States {
+  static getState(name) {
+    if (!name) {
+      return;
+    }
 
-export {
-  State,
-  AdState,
-  ContentState,
-  Preroll,
-  Midroll,
-  Postroll,
-  BeforePreroll,
-  ContentPlayback,
-  AdsDone,
-  StitchedAdRoll,
-  StitchedContentPlayback
-};
+    if (States.states_ && States.states_[name]) {
+      return States.states_[name];
+    }
+  }
+
+  static registerState(name, StateToRegister) {
+    if (typeof name !== 'string' || !name) {
+      throw new Error(`Illegal state name, "${name}"; must be a non-empty string.`);
+    }
+
+    if (!States.states_) {
+      States.states_ = {};
+    }
+
+    States.states_[name] = StateToRegister;
+
+    return StateToRegister;
+  }
+}

--- a/src/states/AdsDone.js
+++ b/src/states/AdsDone.js
@@ -1,8 +1,9 @@
 import videojs from 'video.js';
+import States from '../states.js';
 
-import {ContentState} from '../states.js';
+const ContentState = States.getState('ContentState');
 
-export default class AdsDone extends ContentState {
+class AdsDone extends ContentState {
 
   /*
    * Allows state name to be logged even after minification.
@@ -29,3 +30,7 @@ export default class AdsDone extends ContentState {
   }
 
 }
+
+States.registerState('AdsDone', AdsDone);
+
+export default AdsDone;

--- a/src/states/BeforePreroll.js
+++ b/src/states/BeforePreroll.js
@@ -1,4 +1,6 @@
-import {ContentState, Preroll} from '../states.js';
+import States from '../states.js';
+
+const ContentState = States.getState('ContentState');
 
 /*
  * This is the initial state for a player with an ad plugin. Normally, it remains in this
@@ -6,7 +8,7 @@ import {ContentState, Preroll} from '../states.js';
  * prerolls. This happens regardless of whether or not any prerolls ultimately will play.
  * Errors and other conditions may lead us directly from here to ContentPlayback.
  */
-export default class BeforePreroll extends ContentState {
+class BeforePreroll extends ContentState {
 
   /*
    * Allows state name to be logged even after minification.
@@ -42,6 +44,8 @@ export default class BeforePreroll extends ContentState {
    * content playback is blocked by the ad plugin.
    */
   onPlay(player) {
+    const Preroll = States.getState('Preroll');
+
     player.ads.debug('Received play event (BeforePreroll)');
 
     // Check for prerolls
@@ -88,3 +92,7 @@ export default class BeforePreroll extends ContentState {
   }
 
 }
+
+States.registerState('BeforePreroll', BeforePreroll);
+
+export default BeforePreroll;

--- a/src/states/ContentPlayback.js
+++ b/src/states/ContentPlayback.js
@@ -1,11 +1,13 @@
-import {ContentState, Midroll, Postroll} from '../states.js';
+import States from '../states.js';
+
+const ContentState = States.getState('ContentState');
 
 /*
  * This state represents content playback the first time through before
  * content ends. After content has ended once, we check for postrolls and
  * move on to the AdsDone state rather than returning here.
  */
-export default class ContentPlayback extends ContentState {
+class ContentPlayback extends ContentState {
 
   /*
    * Allows state name to be logged even after minification.
@@ -41,6 +43,8 @@ export default class ContentPlayback extends ContentState {
    * Content ended before postroll checks.
    */
   onReadyForPostroll(player) {
+    const Postroll = States.getState('Postroll');
+
     player.ads.debug('Received readyforpostroll event');
     this.transitionTo(Postroll);
   }
@@ -49,7 +53,13 @@ export default class ContentPlayback extends ContentState {
    * This is how midrolls start.
    */
   startLinearAdMode() {
+    const Midroll = States.getState('Midroll');
+
     this.transitionTo(Midroll);
   }
 
 }
+
+States.registerState('ContentPlayback', ContentPlayback);
+
+export default ContentPlayback;

--- a/src/states/Midroll.js
+++ b/src/states/Midroll.js
@@ -1,7 +1,9 @@
-import {AdState} from '../states.js';
+import States from '../states.js';
 import adBreak from '../adBreak.js';
 
-export default class Midroll extends AdState {
+const AdState = States.getState('AdState');
+
+class Midroll extends AdState {
 
   /*
    * Allows state name to be logged even after minification.
@@ -63,3 +65,7 @@ export default class Midroll extends AdState {
   }
 
 }
+
+States.registerState('Midroll', Midroll);
+
+export default Midroll;

--- a/src/states/Postroll.js
+++ b/src/states/Postroll.js
@@ -1,9 +1,10 @@
 import videojs from 'video.js';
-
-import {AdState, BeforePreroll, Preroll, AdsDone} from '../states.js';
 import adBreak from '../adBreak.js';
+import States from '../states.js';
 
-export default class Postroll extends AdState {
+const AdState = States.getState('AdState');
+
+class Postroll extends AdState {
 
   /*
    * Allows state name to be logged even after minification.
@@ -40,6 +41,9 @@ export default class Postroll extends AdState {
     // No postroll, ads are done
     } else {
       this.resumeContent(player);
+
+      const AdsDone = States.getState('AdsDone');
+
       this.transitionTo(AdsDone);
     }
   }
@@ -73,6 +77,7 @@ export default class Postroll extends AdState {
    */
   endLinearAdMode() {
     const player = this.player;
+    const AdsDone = States.getState('AdsDone');
 
     if (this.inAdBreak()) {
       player.removeClass('vjs-ad-loading');
@@ -129,11 +134,15 @@ export default class Postroll extends AdState {
     // Content resuming after Postroll. Content is paused
     // at this point, since it is done playing.
     if (this.isContentResuming()) {
+      const BeforePreroll = States.getState('BeforePreroll');
+
       this.transitionTo(BeforePreroll);
 
     // Waiting for postroll to start. Content is considered playing
     // at this point, since it had to be playing to start the postroll.
     } else if (!this.inAdBreak()) {
+      const Preroll = States.getState('Preroll');
+
       this.transitionTo(Preroll);
     }
   }
@@ -159,6 +168,8 @@ export default class Postroll extends AdState {
    * refactor this class so that `cleanup` handles all of this.
    */
   abort(player) {
+    const AdsDone = States.getState('AdsDone');
+
     this.resumeContent(player);
     player.removeClass('vjs-ad-loading');
     this.transitionTo(AdsDone);
@@ -174,3 +185,7 @@ export default class Postroll extends AdState {
   }
 
 }
+
+States.registerState('Postroll', Postroll);
+
+export default Postroll;

--- a/src/states/Preroll.js
+++ b/src/states/Preroll.js
@@ -1,13 +1,15 @@
 import videojs from 'video.js';
-
-import {AdState} from '../states.js';
 import adBreak from '../adBreak.js';
+
+import States from '../states.js';
+
+const AdState = States.getState('AdState');
 
 /*
  * This state encapsulates waiting for prerolls, preroll playback, and
  * content restoration after a preroll.
  */
-export default class Preroll extends AdState {
+class Preroll extends AdState {
 
   /*
    * Allows state name to be logged even after minification.
@@ -252,3 +254,7 @@ export default class Preroll extends AdState {
   }
 
 }
+
+States.registerState('Preroll', Preroll);
+
+export default Preroll;

--- a/src/states/StitchedAdRoll.js
+++ b/src/states/StitchedAdRoll.js
@@ -1,7 +1,9 @@
-import {AdState, StitchedContentPlayback} from '../states.js';
 import adBreak from '../adBreak.js';
+import States from '../states.js';
 
-export default class StitchedAdRoll extends AdState {
+const AdState = States.getState('AdState');
+
+class StitchedAdRoll extends AdState {
 
   /*
    * Allows state name to be logged even after minification.
@@ -48,7 +50,13 @@ export default class StitchedAdRoll extends AdState {
    * StitchedAdRoll break is done.
    */
   endLinearAdMode() {
+    const StitchedContentPlayback = States.getState('StitchedContentPlayback');
+
     adBreak.end(this.player);
     this.transitionTo(StitchedContentPlayback);
   }
 }
+
+States.registerState('StitchedAdRoll', StitchedAdRoll);
+
+export default StitchedAdRoll;

--- a/src/states/StitchedContentPlayback.js
+++ b/src/states/StitchedContentPlayback.js
@@ -1,9 +1,11 @@
-import {ContentState, StitchedAdRoll} from '../states.js';
+import States from '../states.js';
+
+const ContentState = States.getState('ContentState');
 
 /*
  * This state represents content playback when stitched ads are in play.
  */
-export default class StitchedContentPlayback extends ContentState {
+class StitchedContentPlayback extends ContentState {
 
   /*
    * Allows state name to be logged even after minification.
@@ -35,6 +37,12 @@ export default class StitchedContentPlayback extends ContentState {
    * This is how stitched ads start.
    */
   startLinearAdMode() {
+    const StitchedAdRoll = States.getState('StitchedAdRoll');
+
     this.transitionTo(StitchedAdRoll);
   }
 }
+
+States.registerState('StitchedContentPlayback', StitchedContentPlayback);
+
+export default StitchedContentPlayback;

--- a/src/states/abstract/AdState.js
+++ b/src/states/abstract/AdState.js
@@ -1,11 +1,12 @@
-import {State, ContentPlayback} from '../../states.js';
+import States from '../../states.js';
+import State from './State.js';
 
 /*
  * This class contains logic for all ads, be they prerolls, midrolls, or postrolls.
  * Primarily, this involves handling startLinearAdMode and endLinearAdMode.
  * It also handles content resuming.
  */
-export default class AdState extends State {
+class AdState extends State {
 
   constructor(player) {
     super(player);
@@ -25,6 +26,8 @@ export default class AdState extends State {
    * moment that content playback is no longer blocked by ads.
    */
   onPlaying() {
+    const ContentPlayback = States.getState('ContentPlayback');
+
     if (this.contentResuming) {
       this.transitionTo(ContentPlayback);
     }
@@ -36,6 +39,8 @@ export default class AdState extends State {
    * resume. The main use case for this is when ads are stitched into the content video.
    */
   onContentResumed() {
+    const ContentPlayback = States.getState('ContentPlayback');
+
     if (this.contentResuming) {
       this.transitionTo(ContentPlayback);
     }
@@ -64,3 +69,7 @@ export default class AdState extends State {
   }
 
 }
+
+States.registerState('AdState', AdState);
+
+export default AdState;

--- a/src/states/abstract/ContentState.js
+++ b/src/states/abstract/ContentState.js
@@ -1,6 +1,7 @@
-import {State, BeforePreroll, Preroll} from '../../states.js';
+import States from '../../states.js';
+import State from './State.js';
 
-export default class ContentState extends State {
+class ContentState extends State {
 
   /*
    * Overrides State.isAdState
@@ -14,6 +15,9 @@ export default class ContentState extends State {
    * fire during ad breaks, so we don't need to worry about that.
    */
   onContentChanged(player) {
+    const BeforePreroll = States.getState('BeforePreroll');
+    const Preroll = States.getState('Preroll');
+
     player.ads.debug('Received contentchanged event (ContentState)');
     if (player.paused()) {
       this.transitionTo(BeforePreroll);
@@ -25,3 +29,7 @@ export default class ContentState extends State {
   }
 
 }
+
+States.registerState('ContentState', ContentState);
+
+export default ContentState;

--- a/src/states/abstract/State.js
+++ b/src/states/abstract/State.js
@@ -1,6 +1,7 @@
 import videojs from 'video.js';
+import States from '../../states.js';
 
-export default class State {
+class State {
 
   static _getName() {
     return 'Anonymous State';
@@ -143,3 +144,7 @@ export default class State {
   }
 
 }
+
+States.registerState('State', State);
+
+export default State;

--- a/test/unit/states/abstract/test.AdState.js
+++ b/test/unit/states/abstract/test.AdState.js
@@ -1,5 +1,5 @@
 import QUnit from 'qunit';
-import {AdState} from '../../../../src/states.js';
+import AdState from '../../../../src/states/abstract/AdState.js';
 
 /*
  * These tests are intended to be isolated unit tests for one state with all

--- a/test/unit/states/abstract/test.ContentState.js
+++ b/test/unit/states/abstract/test.ContentState.js
@@ -1,6 +1,6 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
-import {ContentState} from '../../../../src/states.js';
+import ContentState from '../../../../src/states/abstract/ContentState.js';
 
 /*
  * These tests are intended to be isolated unit tests for one state with all

--- a/test/unit/states/abstract/test.State.js
+++ b/test/unit/states/abstract/test.State.js
@@ -1,6 +1,6 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
-import {State} from '../../../../src/states.js';
+import State from '../../../../src/states/abstract/State.js';
 
 /*
  * These tests are intended to be isolated unit tests for one state with all

--- a/test/unit/states/test.AdsDone.js
+++ b/test/unit/states/test.AdsDone.js
@@ -1,6 +1,6 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
-import {AdsDone} from '../../../src/states.js';
+import AdsDone from '../../../src/states/AdsDone.js';
 
 /*
  * These tests are intended to be isolated unit tests for one state with all

--- a/test/unit/states/test.BeforePreroll.js
+++ b/test/unit/states/test.BeforePreroll.js
@@ -1,7 +1,7 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
 
-import {BeforePreroll} from '../../../src/states.js';
+import BeforePreroll from '../../../src/states/BeforePreroll.js';
 import * as CancelContentPlay from '../../../src/cancelContentPlay.js';
 
 /*

--- a/test/unit/states/test.ContentPlayback.js
+++ b/test/unit/states/test.ContentPlayback.js
@@ -1,5 +1,5 @@
 import QUnit from 'qunit';
-import {ContentPlayback} from '../../../src/states.js';
+import ContentPlayback from '../../../src/states/ContentPlayback.js';
 
 /*
  * These tests are intended to be isolated unit tests for one state with all

--- a/test/unit/states/test.Midroll.js
+++ b/test/unit/states/test.Midroll.js
@@ -1,6 +1,6 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
-import {Midroll} from '../../../src/states.js';
+import Midroll from '../../../src/states/Midroll.js';
 import adBreak from '../../../src/adBreak.js';
 
 /*

--- a/test/unit/states/test.Postroll.js
+++ b/test/unit/states/test.Postroll.js
@@ -1,6 +1,6 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
-import {Postroll} from '../../../src/states.js';
+import Postroll from '../../../src/states/Postroll.js';
 import adBreak from '../../../src/adBreak.js';
 
 /*

--- a/test/unit/states/test.Preroll.js
+++ b/test/unit/states/test.Preroll.js
@@ -1,6 +1,6 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
-import {Preroll} from '../../../src/states.js';
+import Preroll from '../../../src/states/Preroll.js';
 import adBreak from '../../../src/adBreak.js';
 
 /*

--- a/test/unit/states/test.StitchedAdRoll.js
+++ b/test/unit/states/test.StitchedAdRoll.js
@@ -1,6 +1,6 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
-import {StitchedAdRoll} from '../../../src/states.js';
+import StitchedAdRoll from '../../../src/states/StitchedAdRoll.js';
 import adBreak from '../../../src/adBreak.js';
 
 /*

--- a/test/unit/states/test.StitchedContentPlayback.js
+++ b/test/unit/states/test.StitchedContentPlayback.js
@@ -1,4 +1,4 @@
-import {StitchedContentPlayback} from '../../../src/states.js';
+import StitchedContentPlayback from '../../../src/states/StitchedContentPlayback.js';
 import QUnit from 'qunit';
 
 /*


### PR DESCRIPTION
Currently there is a circular dependency issue that locks this repository to an old version of rollup, and thus an old version of the generator. This pull request seeks to remedy that. I implemented a registration system similar to what we have for Components in Video.js, but it will be for States here.