### PR TITLE
feat: Add width and height macros

### DIFF
--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -28,7 +28,7 @@ adMacroReplacement takes 3 arguments:
 |:-------------------------|:-------------------------------|
 | {player.id}              | The player ID                  |
 | {player.width}           | The current player width       |
-| {player.heigth}          | The current player heigth      |
+| {player.height}          | The current player height      |
 | {player.duration}        | The duration of current video* |
 | {timestamp}              | Current epoch time             |
 | {document.referrer}      | Value of document.referrer     |

--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -27,6 +27,8 @@ adMacroReplacement takes 3 arguments:
 | Name                     | Value                          |
 |:-------------------------|:-------------------------------|
 | {player.id}              | The player ID                  |
+| {player.width}           | The current player width       |
+| {player.heigth}          | The current player heigth      |
 | {player.duration}        | The duration of current video* |
 | {timestamp}              | Current epoch time             |
 | {document.referrer}      | Value of document.referrer     |

--- a/src/macros.js
+++ b/src/macros.js
@@ -61,6 +61,8 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
 
   // Static macros
   macros['{player.id}'] = this.options_['data-player'];
+  macros['{player.height}'] = this.currentHeight();
+  macros['{player.width}'] = this.currentWidth();
   macros['{mediainfo.id}'] = this.mediainfo ? this.mediainfo.id : '';
   macros['{mediainfo.name}'] = this.mediainfo ? this.mediainfo.name : '';
   macros['{mediainfo.duration}'] = this.mediainfo ? this.mediainfo.duration : '';

--- a/test/integration/test.macros.js
+++ b/test/integration/test.macros.js
@@ -12,6 +12,17 @@ QUnit.test('player.id', function(assert) {
   assert.equal(result, '12345');
 });
 
+QUnit.test('player.height', function(assert) {
+  this.player.options_['data-player'] = '12345';
+  this.player.dimensions(200, 100);
+
+  const resultHeight = this.player.ads.adMacroReplacement('{player.height}');
+  const resultWidth = this.player.ads.adMacroReplacement('{player.width}');
+
+  assert.equal(resultHeight, 100);
+  assert.equal(resultWidth, 200);
+});
+
 QUnit.test('mediainfo', function(assert) {
   /* eslint-disable camelcase */
   this.player.mediainfo = {

--- a/test/integration/test.macros.js
+++ b/test/integration/test.macros.js
@@ -12,15 +12,15 @@ QUnit.test('player.id', function(assert) {
   assert.equal(result, '12345');
 });
 
-QUnit.test('player.height', function(assert) {
+QUnit.test('player dimensions', function(assert) {
   this.player.options_['data-player'] = '12345';
   this.player.dimensions(200, 100);
 
   const resultHeight = this.player.ads.adMacroReplacement('{player.height}');
   const resultWidth = this.player.ads.adMacroReplacement('{player.width}');
 
-  assert.equal(resultHeight, 100);
-  assert.equal(resultWidth, 200);
+  assert.equal(resultHeight, 100, 'player.height was replaced');
+  assert.equal(resultWidth, 200, 'player.width was replaced');
 });
 
 QUnit.test('mediainfo', function(assert) {


### PR DESCRIPTION
Adds macros for player width and height. Uses the `player.current*` methods, as this is more relevant in an ad call than the configured dimensions.

Updates docs and tests.