### PR TITLE
feat: add pageUrl macro

### DIFF
--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -28,6 +28,7 @@ adMacroReplacement takes 3 arguments:
 |:-------------------------|:-------------------------------|
 | {player.id}              | The player ID                  |
 | {player.duration}        | The duration of current video* |
+| {player.pageUrl}         | The page URL **                |
 | {timestamp}              | Current epoch time             |
 | {document.referrer}      | Value of document.referrer     |
 | {window.location.href}   | Value of window.location.href  |
@@ -41,6 +42,7 @@ adMacroReplacement takes 3 arguments:
 | {mediainfo.ad_keys}      | Pulled from mediainfo object   |
 
 \* Returns 0 if video is not loaded. Be careful timing your ad request with this macro.
+\** Returns document referrer if in an iframe otherwise window location.
 
 ## Dynamic Macro: mediainfo.custom_fields.*
 

--- a/src/macros.js
+++ b/src/macros.js
@@ -65,6 +65,8 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
   macros['{mediainfo.name}'] = this.mediainfo ? this.mediainfo.name : '';
   macros['{mediainfo.duration}'] = this.mediainfo ? this.mediainfo.duration : '';
   macros['{player.duration}'] = this.duration();
+  // When not in an iframe, window.location and window.parent.location are the same
+  // Within an iframe, window.parent.location is different or inaccessible
   macros['{player.pageUrl}'] = (window.location !== window.parent.location) ?
     document.referrer :
     window.location.href;

--- a/src/macros.js
+++ b/src/macros.js
@@ -65,6 +65,9 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
   macros['{mediainfo.name}'] = this.mediainfo ? this.mediainfo.name : '';
   macros['{mediainfo.duration}'] = this.mediainfo ? this.mediainfo.duration : '';
   macros['{player.duration}'] = this.duration();
+  macros['{player.pageUrl}'] = (window.location !== window.parent.location) ?
+    document.referrer :
+    window.location.href;
   macros['{timestamp}'] = new Date().getTime();
   macros['{document.referrer}'] = document.referrer;
   macros['{window.location.href}'] = window.location.href;

--- a/src/macros.js
+++ b/src/macros.js
@@ -65,11 +65,7 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
   macros['{mediainfo.name}'] = this.mediainfo ? this.mediainfo.name : '';
   macros['{mediainfo.duration}'] = this.mediainfo ? this.mediainfo.duration : '';
   macros['{player.duration}'] = this.duration();
-  // When not in an iframe, window.location and window.parent.location are the same
-  // Within an iframe, window.parent.location is different or inaccessible
-  macros['{player.pageUrl}'] = (window.location !== window.parent.location) ?
-    document.referrer :
-    window.location.href;
+  macros['{player.pageUrl}'] = videojs.dom.isInFrame() ? document.referrer : window.location.href;
   macros['{timestamp}'] = new Date().getTime();
   macros['{document.referrer}'] = document.referrer;
   macros['{window.location.href}'] = window.location.href;

--- a/test/integration/test.macros.js
+++ b/test/integration/test.macros.js
@@ -44,6 +44,12 @@ QUnit.test('player.duration', function(assert) {
   assert.equal(result, 5);
 });
 
+QUnit.test('player.pageUrl', function(assert) {
+  const result = this.player.ads.adMacroReplacement('{player.pageUrl}');
+
+  assert.equal(result, document.referrer, 'tests run in iframe, so referrer should be used');
+});
+
 QUnit.test('timestamp', function(assert) {
   this.player.duration = function() {
     return 5;


### PR DESCRIPTION
Adds a `player.pageUrl` macro. This is intended as the URL at which the player has been embedded, whether directly or via an iframe. The name of the macro hopefully makes it clear that this is not an embed URL for the player itself.

If the player is in an iframe, this resolves to `document.referrer`, otherwise to `window.location.href`.

A test is only included for the iframe case for now, as the tests themselves run in an iframe.