### PR TITLE
Change log message level from 'info' to 'debug'.

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -64,7 +64,7 @@ function register(contribAdsPlugin) {
     // Register the play middleware
     videojs.use('*', playMiddleware);
     videojs.usingContribAdsMiddleware_ = true;
-    videojs.log('Play middleware has been registered with videojs');
+    videojs.log.debug('Play middleware has been registered with videojs');
   }
 
   return true;


### PR DESCRIPTION
I use contrib-ads to display ads in my player. 
Everything works pretty well but there is one irritating thing. 
Every time I load the page with the player and ads I see the following console message:
![image](https://user-images.githubusercontent.com/5346546/57457642-3275df00-7270-11e9-9950-a6a2c535f8ad.png)
I manage to fix that changing the log level from 'info' to 'debug' for this specific message.
Do you have a different idea? how to resolve it.