### PR TITLE
Fix: on auto-play don't request playback for stitched ads as well as when playback already started

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -134,6 +134,12 @@ const contribAdsPlugin = function(options) {
   // cannot play from adcanplay.
   // This will prevent ad plugins from needing to do this themselves.
   player.on(['addurationchange', 'adcanplay'], function() {
+    // Some techs may retrigger canplay after playback has begun.
+    // So we want to procceed only if playback hasn't started.
+    if (player.hasStarted()) {
+      return;
+    }
+
     if (player.ads.snapshot && player.currentSrc() === player.ads.snapshot.currentSrc) {
       return;
     }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -134,6 +134,11 @@ const contribAdsPlugin = function(options) {
   // cannot play from adcanplay.
   // This will prevent ad plugins from needing to do this themselves.
   player.on(['addurationchange', 'adcanplay'], function() {
+    // We don't need to handle this for stitched ads because
+    // linear ads in such cases are stitched into the content.
+    if (player.ads.settings.stitchedAds) {
+      return;
+    }
     // Some techs may retrigger canplay after playback has begun.
     // So we want to procceed only if playback hasn't started.
     if (player.hasStarted()) {


### PR DESCRIPTION
Some techs, e.g. Flash may re-trigger `canplay` after playback has begun which can result in requesting playback when playback is already progressing. When assuming auto-play, playback should be requested only if it hasn't started. We also don't need to handle auto-playback for stitched ads because linear ads in such cases are stitched into the content.