### PR TITLE
feat: Add playlistinfo macros

### DIFF
--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -39,6 +39,8 @@ adMacroReplacement takes 3 arguments:
 | {mediainfo.reference_id} | Pulled from mediainfo object   |
 | {mediainfo.duration}     | Pulled from mediainfo object   |
 | {mediainfo.ad_keys}      | Pulled from mediainfo object   |
+| {playlistinfo.id}        | Pulled from playlistinfo object   |
+| {playlistinfo.name}      | Pulled from playlistinfo object   |
 
 \* Returns 0 if video is not loaded. Be careful timing your ad request with this macro.
 

--- a/src/macros.js
+++ b/src/macros.js
@@ -65,6 +65,8 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
   macros['{mediainfo.name}'] = this.mediainfo ? this.mediainfo.name : '';
   macros['{mediainfo.duration}'] = this.mediainfo ? this.mediainfo.duration : '';
   macros['{player.duration}'] = this.duration();
+  macros['{playlistinfo.id}'] = this.playlistinfo ? this.playlistinfo.id : '';
+  macros['{playlistinfo.name}'] = this.playlistinfo ? this.playlistinfo.name : '';
   macros['{timestamp}'] = new Date().getTime();
   macros['{document.referrer}'] = document.referrer;
   macros['{window.location.href}'] = window.location.href;

--- a/test/integration/test.macros.js
+++ b/test/integration/test.macros.js
@@ -35,6 +35,17 @@ QUnit.test('mediainfo', function(assert) {
   assert.equal(result, '1234567');
 });
 
+QUnit.test('playlistinfo', function(assert) {
+  this.player.playlistinfo = {
+    id: 1,
+    name: 2
+  };
+  const result = this.player.ads.adMacroReplacement('{playlistinfo.id}' +
+    '{playlistinfo.name}');
+
+  assert.equal(result, '12');
+});
+
 QUnit.test('player.duration', function(assert) {
   this.player.duration = function() {
     return 5;


### PR DESCRIPTION
Adds `{playlistinfo.id}` and `{playlistinfo.name}` macros for ad targeting by playlist.