### PR TITLE
No loading spinner after the preroll ad has finished and before the actual content starts.

### DIFF
--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -27,12 +27,20 @@ Styles for ad plugins.
     display: none;
 }
 
+.vjs-ad-content-resuming .vjs-loading-spinner {
+  display: block;
+  // add a delay before actual show the spinner
+  animation: vjs-spinner-show 0s linear 0.3s forwards;
+}
+
 /* Following is copied from https://github.com/videojs/video.js/blob/master/src/css/components/_loading.scss
  this is needed to animate the spinner when ads, specifically VPAIDs, are loading.
  Long term solution is to add show/hide methods to the loading spinner component and move to displaying it via the methods rather than CSS.
 */
 .vjs-ad-loading .vjs-loading-spinner:before,
-.vjs-ad-loading .vjs-loading-spinner:after {
+.vjs-ad-loading .vjs-loading-spinner:after,
+.vjs-ad-content-resuming .vjs-loading-spinner:before,
+.vjs-ad-content-resuming .vjs-loading-spinner:after {
   -webkit-animation: vjs-spinner-spin 1.1s cubic-bezier(0.6, 0.2, 0, 0.8) infinite, vjs-spinner-fade 1.1s linear infinite;
   animation: vjs-spinner-spin 1.1s cubic-bezier(0.6, 0.2, 0, 0.8) infinite, vjs-spinner-fade 1.1s linear infinite;
 }


### PR DESCRIPTION
This PR should resolve #95 issue.