### PR TITLE
Fix: Player does not trigger 'play' and 'pause' events first time after AdBlocker block Ads

### DIFF
--- a/src/states/Preroll.js
+++ b/src/states/Preroll.js
@@ -210,8 +210,11 @@ class Preroll extends AdState {
    */
   onAdTimeout(player) {
     this.afterLoadStart(() => {
+      const ContentPlayback = States.getState('ContentPlayback');
+
       player.ads.debug('adtimeout (Preroll)');
       this.resumeAfterNoPreroll(player);
+      this.transitionTo(ContentPlayback);
     });
   }
 

--- a/test/integration/test.ads.js
+++ b/test/integration/test.ads.js
@@ -117,8 +117,8 @@ QUnit.test('begins resuming to content if there is no preroll', function(assert)
   this.player.trigger('adtimeout');
 
   assert.strictEqual(this.player.ads.inAdBreak(), false, 'should not be in an ad break');
-  assert.strictEqual(this.player.ads.isContentResuming(), true, 'should be resuming content');
-  assert.strictEqual(this.player.ads.isInAdMode(), true, 'should be in ad mode');
+  assert.strictEqual(this.player.ads.isContentResuming(), false, 'should not be resuming content after timeout');
+  assert.strictEqual(this.player.ads.isInAdMode(), false, 'should not  be in ad mode after timeout');
 });
 
 QUnit.test('removes the poster attribute so it does not flash between videos', function(assert) {
@@ -438,7 +438,7 @@ QUnit.test('adsready while preroll content resuming triggers readyforpreroll', f
   this.player.trigger('loadstart');
   this.player.trigger('play');
   this.player.trigger('adtimeout');
-  assert.strictEqual(this.player.ads.isContentResuming(), true, 'should be resuming to content');
+  assert.strictEqual(this.player.ads.isContentResuming(), false, 'should not be resuming to content');
   this.player.trigger('adsready');
   assert.strictEqual(spy.callCount, 1, 'readyforpreroll should have been triggered.');
 });


### PR DESCRIPTION
**Problem Description**

When Preroll is blocked due to AdBlocker the plugin will trigger an `adtimeout` event then content will play without any event trigger like `play` or `contentplay` or transition to `ContentPlayback` state. So, the first event triggered if we call `player.play()` or `player.pause()` will be prefixed with `content` (`contentpause` or `contentplay`) and plugin will transition from `Preroll -> ContentPlayback` because we are in `Preroll` stuck. 

**Solution Proposal**

When we have and `adtimeout` in `Preroll` state transition to `ContentPlayback` 