### PR TITLE
fix: Ad plugin stuck in Preroll when adserror due empty VAST

### DIFF
--- a/src/states/Preroll.js
+++ b/src/states/Preroll.js
@@ -240,9 +240,16 @@ class Preroll extends AdState {
       const playPromise = player.play();
 
       if (playPromise && playPromise.then) {
-        playPromise.then(null, (e) => {});
+        playPromise.then(null, (e) => { });
       }
+      // When Ad plugin throws and adserror (Preroll) after initialation due AdError 1009: The VAST response document is empty
+      // ad plugin state won't transition from Preroll -> ContentPlayback and will be stuck in AdMode
+      // so any event like timeupdate will be redispatched with the prefix content (contenttimeupdate)
+    } else if (!player.paused() && !player.ads.inAdBreak() && !player.ads.isAdPlaying() && player.ads.isContentResuming()) {
+      // trigger contentresumed to switch from Preroll -> ContentPlayback
+      player.trigger('contentresumed');
     }
+
   }
 
   /*

--- a/src/states/Preroll.js
+++ b/src/states/Preroll.js
@@ -143,10 +143,16 @@ class Preroll extends AdState {
     } else {
       this.afterLoadStart(() => {
         this.resumeAfterNoPreroll(player);
+        // When Ad plugin throws and adserror (Preroll) after initialation due AdError 1009: The VAST response document is empty
+        // ad plugin state won't transition from Preroll -> ContentPlayback and will be stuck in AdMode
+        // so any event like timeupdate will be redispatched with the prefix content (contenttimeupdate)
+        if (!player.paused() && !player.ads.inAdBreak() && player.ads.isContentResuming()) {
+          // trigger contentresumed to switch from Preroll -> ContentPlayback
+          player.trigger('contentresumed');
+        }
       });
     }
   }
-
   /*
    * Ad plugin invoked startLinearAdMode, the ad break starts now.
    */
@@ -242,12 +248,6 @@ class Preroll extends AdState {
       if (playPromise && playPromise.then) {
         playPromise.then(null, (e) => { });
       }
-      // When Ad plugin throws and adserror (Preroll) after initialation due AdError 1009: The VAST response document is empty
-      // ad plugin state won't transition from Preroll -> ContentPlayback and will be stuck in AdMode
-      // so any event like timeupdate will be redispatched with the prefix content (contenttimeupdate)
-    } else if (!player.paused() && !player.ads.inAdBreak() && !player.ads.isAdPlaying() && player.ads.isContentResuming()) {
-      // trigger contentresumed to switch from Preroll -> ContentPlayback
-      player.trigger('contentresumed');
     }
 
   }

--- a/src/states/Preroll.js
+++ b/src/states/Preroll.js
@@ -247,6 +247,7 @@ class Preroll extends AdState {
 
       } else {
         player.ads.debug('resumeAfterNoPreroll: already playing (Preroll)');
+        player.trigger('play');
         player.trigger('playing');
       }
     }

--- a/src/states/Preroll.js
+++ b/src/states/Preroll.js
@@ -143,13 +143,6 @@ class Preroll extends AdState {
     } else {
       this.afterLoadStart(() => {
         this.resumeAfterNoPreroll(player);
-        // When Ad plugin throws and adserror (Preroll) after initialation due AdError 1009: The VAST response document is empty
-        // ad plugin state won't transition from Preroll -> ContentPlayback and will be stuck in AdMode
-        // so any event like timeupdate will be redispatched with the prefix content (contenttimeupdate)
-        if (!player.paused() && !player.ads.inAdBreak() && player.ads.isContentResuming()) {
-          // trigger contentresumed to switch from Preroll -> ContentPlayback
-          player.trigger('contentresumed');
-        }
       });
     }
   }
@@ -242,11 +235,19 @@ class Preroll extends AdState {
     // Play the content if we had requested play or we paused on 'contentupdate'
     // and we haven't played yet. This happens if there was no preroll or if it
     // errored, timed out, etc. Otherwise snapshot restore would play.
-    if (player.paused() && (player.ads._playRequested || player.ads._pausedOnContentupdate)) {
-      const playPromise = player.play();
+    if (player.ads._playRequested || player.ads._pausedOnContentupdate) {
+      if (player.paused()) {
+        player.ads.debug('resumeAfterNoPreroll: attempting to resume playback (Preroll)');
 
-      if (playPromise && playPromise.then) {
-        playPromise.then(null, (e) => { });
+        const playPromise = player.play();
+
+        if (playPromise && playPromise.then) {
+          playPromise.then(null, function(e) { });
+        }
+
+      } else {
+        player.ads.debug('resumeAfterNoPreroll: already playing (Preroll)');
+        player.trigger('playing');
       }
     }
 

--- a/test/integration/test.cancelContentPlay.js
+++ b/test/integration/test.cancelContentPlay.js
@@ -110,8 +110,8 @@ QUnit.test("cancelContentPlay doesn\'t block play in content playback", function
   this.player.trigger('play');
   assert.strictEqual(pauseSpy.callCount, 1, 'pause should have been called');
   assert.strictEqual(
-    this.player.ads._cancelledPlay, true,
-    'cancelContentPlay is called while resuming'
+    this.player.ads._cancelledPlay, false,
+    'cancelContentPlay is not called while resuming'
   );
 
   // enters ContentPlayback

--- a/test/unit/states/test.Preroll.js
+++ b/test/unit/states/test.Preroll.js
@@ -246,3 +246,19 @@ QUnit.test('resets _shouldBlockPlay to false when no preroll', function(assert) 
   this.preroll.resumeAfterNoPreroll(this.player);
   assert.equal(this.player.ads._shouldBlockPlay, false);
 });
+
+QUnit.test('adserror (Preroll) will trigger playing if its already playing', function(assert) {
+  this.preroll.init(this.player, false, false);
+  this.playingTriggered = false;
+  // due AdError 1009: The VAST response document is empty
+  this.player.ads._playRequested = true;
+  this.player.ads._pausedOnContentupdate = false;
+  this.player.paused = () => false;
+  this.preroll.onAdsError(this.player);
+
+  assert.equal(this.preroll.adType, null);
+  assert.equal(this.events[0], 'playing', 'playing from adserror');
+  assert.equal(this.player.ads._shouldBlockPlay, false);
+  assert.equal(this.preroll.isContentResuming(), true);
+
+});

--- a/test/unit/states/test.Preroll.js
+++ b/test/unit/states/test.Preroll.js
@@ -247,7 +247,7 @@ QUnit.test('resets _shouldBlockPlay to false when no preroll', function(assert) 
   assert.equal(this.player.ads._shouldBlockPlay, false);
 });
 
-QUnit.test('adserror (Preroll) will trigger playing if its already playing', function(assert) {
+QUnit.test('adserror (Preroll) will trigger play & playing if its already playing', function(assert) {
   this.preroll.init(this.player, false, false);
   this.playingTriggered = false;
   // due AdError 1009: The VAST response document is empty
@@ -257,7 +257,8 @@ QUnit.test('adserror (Preroll) will trigger playing if its already playing', fun
   this.preroll.onAdsError(this.player);
 
   assert.equal(this.preroll.adType, null);
-  assert.equal(this.events[0], 'playing', 'playing from adserror');
+  assert.equal(this.events[0], 'play', 'playing from adserror');
+  assert.equal(this.events[1], 'playing', 'playing from adserror');
   assert.equal(this.player.ads._shouldBlockPlay, false);
   assert.equal(this.preroll.isContentResuming(), true);
 


### PR DESCRIPTION
**Problem Description**

When the Ads plugin throws an `adserror (Preroll)` due `AdError 1009: The VAST response document is empty` is getting stuck in the `Preroll` state and not switching to `ContentPlayback`  because of this behavior the Ads plugin is dispatching `timeupdate` as `contenttimeupdate`. So, in and `adserror` we want to transition to `ContentPlayback` with a `contentresumed` if the player is actually playing content. 