### PR TITLE
Add TCF macro support

### DIFF
--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -24,29 +24,32 @@ adMacroReplacement takes 3 arguments:
 
 ## Static Macros
 
-| Name                     | Value                          |
-|:-------------------------|:-------------------------------|
-| {player.id}              | The player ID                  |
-| {player.width}           | The current player width       |
-| {player.height}          | The current player height      |
-| {player.duration}        | The duration of current video* |
-| {player.pageUrl}         | The page URL **                |
-| {timestamp}              | Current epoch time             |
-| {document.referrer}      | Value of document.referrer     |
-| {window.location.href}   | Value of window.location.href  |
-| {random}                 | A random number 0-1 trillion   |
-| {mediainfo.id}           | Pulled from mediainfo object   |
-| {mediainfo.name}         | Pulled from mediainfo object   |
-| {mediainfo.description}  | Pulled from mediainfo object   |
-| {mediainfo.tags}         | Pulled from mediainfo object   |
-| {mediainfo.reference_id} | Pulled from mediainfo object   |
-| {mediainfo.duration}     | Pulled from mediainfo object   |
-| {mediainfo.ad_keys}      | Pulled from mediainfo object   |
+| Name                     | Value                             |
+|:-------------------------|:----------------------------------|
+| {player.id}              | The player ID                     |
+| {player.width}           | The current player width          |
+| {player.height}          | The current player height         |
+| {player.duration}        | The duration of current video *   |
+| {player.pageUrl}         | The page URL ** ***               |
+| {timestamp}              | Current epoch time                |
+| {document.referrer}      | Value of document.referrer ***    |
+| {window.location.href}   | Value of window.location.href     |
+| {random}                 | A random number 0-1 trillion      |
+| {mediainfo.id}           | Pulled from mediainfo object      |
+| {mediainfo.name}         | Pulled from mediainfo object      |
+| {mediainfo.description}  | Pulled from mediainfo object      |
+| {mediainfo.tags}         | Pulled from mediainfo object      |
+| {mediainfo.reference_id} | Pulled from mediainfo object      |
+| {mediainfo.duration}     | Pulled from mediainfo object      |
+| {mediainfo.ad_keys}      | Pulled from mediainfo object      |
 | {playlistinfo.id}        | Pulled from playlistinfo object   |
 | {playlistinfo.name}      | Pulled from playlistinfo object   |
 
 \* Returns 0 if video is not loaded. Be careful timing your ad request with this macro.
+
 \** Returns document referrer if in an iframe otherwise window location.
+
+\*** Docuemnt referrer may not return the full URL depending on the effective [referrer policy][referrer-policy].
 
 ## Dynamic Macro: mediainfo.custom_fields.*
 
@@ -65,6 +68,23 @@ A macro such as {pageVariable.foobar} allows the user access the value of any pr
 | Undefined | Logs warning and returns empty string |
 | Other     | Logs warning and returns empty string |
 
+## TCF macros
+
+If a CMP supporting the [GDPR Transparency and Consent Framework][tcf] is in use additional tcf macros are made available. The syntax is `{tcf.*}`, with `*` being a property in the [tcData][tcdata] object. Most commonly used will be:
+
+| Name                     | Value                                       |
+|:-------------------------|:--------------------------------------------|
+| {tcf.gdprApplies}        | Whether GDPR applies to the current session |
+| {tcf.tcString}           | The consent string                          |
+
+Since `gdprApplies` is a boolean and many ad servers expect the value as an int, an additional `{tcf.gdprAppliesInt}` is provided which will return `1` or `0`.
+
+If the player is in an iframe, a proxy will be added if any parent frame is detected to gain consent with the postmessage API. The CMP must be loaded first.
+
 ## Default values in macros
 
 A default value can be provided within a macro, in which case this value will be used where not resolvable e.g. `http://example.com/ad/{pageVariable.adConf=1234}` becomes `http://example.com/ad/1234` if `window.adConf` is undefined.
+
+[tcf]: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
+[tcdata]: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#tcdata
+[referrer-policy]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -49,7 +49,7 @@ adMacroReplacement takes 3 arguments:
 
 \** Returns document referrer if in an iframe otherwise window location.
 
-\*** Docuemnt referrer may not return the full URL depending on the effective [referrer policy][referrer-policy].
+\*** Document referrer may not return the full URL depending on the effective [referrer policy][referrer-policy].
 
 ## Dynamic Macro: mediainfo.custom_fields.*
 

--- a/src/macros.js
+++ b/src/macros.js
@@ -8,6 +8,8 @@ import document from 'global/document';
 
 import videojs from 'video.js';
 
+import { tcData } from './tcf.js';
+
 // Return URI encoded version of value if uriEncode is true
 const uriEncodeIfNeeded = function(value, uriEncode) {
   if (uriEncode) {
@@ -60,7 +62,7 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
   }
 
   // Static macros
-  macros['{player.id}'] = this.options_['data-player'];
+  macros['{player.id}'] = this.options_['data-player'] || this.id_;
   macros['{player.height}'] = this.currentHeight();
   macros['{player.width}'] = this.currentWidth();
   macros['{mediainfo.id}'] = this.mediainfo ? this.mediainfo.id : '';
@@ -88,6 +90,14 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
   // Custom fields in mediainfo
   customFields(this.mediainfo, macros, 'custom_fields');
   customFields(this.mediainfo, macros, 'customFields');
+
+  // tcf macros
+  Object.keys(tcData).forEach(key => {
+    macros[`{tcf.${key}}`] = tcData[key];
+  });
+
+  // Ad servers commonly want this bool as an int
+  macros['{tcf.gdprAppliesInt}'] = tcData.gdprApplies ? 1 : 0;
 
   // Go through all the replacement macros and apply them to the string.
   // This will replace all occurrences of the replacement macros.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -15,6 +15,7 @@ import cueTextTracks from './cueTextTracks.js';
 import initCancelContentPlay from './cancelContentPlay.js';
 import playMiddlewareFeature from './playMiddleware.js';
 import register from './register.js';
+import { listenToTcf } from './tcf.js';
 
 import States from './states.js';
 import './states/abstract/State.js';
@@ -283,6 +284,12 @@ const contribAdsPlugin = function(options) {
     player.ads.reset();
     player.textTracks().removeEventListener('change', textTrackChangeHandler);
   });
+
+  // Listen to TCF changes
+  listenToTcf();
+
+  // Can be called for testing, or if the TCF CMP has loaded late
+  player.ads.listenToTcf = listenToTcf;
 
 };
 

--- a/src/tcf.js
+++ b/src/tcf.js
@@ -1,0 +1,91 @@
+import window from 'global/window';
+
+import videojs from 'video.js';
+
+/**
+ * Current tcfData returned from CMP
+ * Updated on event listener rather than having to make an asyc
+ * check within the macro resolver
+ */
+export let tcData = {};
+
+/**
+ * Sets up a proxy for the TCF API in an iframed player, if a parent frame
+ * that has implemented the TCF API is detected
+ * https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#is-there-a-sample-iframe-script-call-to-the-cmp-api
+ */
+const proxyTcfApi = _ => {
+  if (videojs.dom.isInFrame() && typeof window.__tcfapi !== 'function') {
+    let frame = window;
+    let cmpFrame;
+    const cmpCallbacks = {};
+
+    while (frame) {
+      try {
+        if (frame.frames.__tcfapiLocator) {
+          cmpFrame = frame;
+          break;
+        }
+      } catch (ignore) {
+        // empty
+      }
+      if (frame === window.top) {
+        break;
+      }
+      frame = frame.parent;
+    }
+
+    if (!cmpFrame) {
+      return;
+    }
+
+    window.__tcfapi = function(cmd, version, callback, arg) {
+      const callId = Math.random() + '';
+      const msg = {
+        __tcfapiCall: {
+          command: cmd,
+          parameter: arg,
+          version,
+          callId
+        }
+      };
+
+      cmpCallbacks[callId] = callback;
+      cmpFrame.postMessage(msg, '*');
+    };
+
+    window.addEventListener('message', function(event) {
+      let json = {};
+
+      try {
+        json = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      } catch (ignore) {
+        // empty
+      }
+
+      const payload = json.__tcfapiReturn;
+
+      if (payload) {
+        if (typeof cmpCallbacks[payload.callId] === 'function') {
+          cmpCallbacks[payload.callId](payload.returnValue, payload.success);
+          cmpCallbacks[payload.callId] = null;
+        }
+      }
+    }, false);
+  }
+};
+
+/**
+ * Sets up event listener for changes to consent data.
+ */
+export const listenToTcf = () => {
+  proxyTcfApi();
+
+  if (typeof window.__tcfapi === 'function') {
+    window.__tcfapi('addEventListener', 2, (data, success) => {
+      if (success) {
+        tcData = data;
+      }
+    });
+  }
+};


### PR DESCRIPTION
Adds support for consent string and other TCF metadata generated by a consent management platform for GDPR.

This will add a macro for any property of the [tcData object](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#tcdata). Most notable are `{tcf.gdprApplies}` and `{tcf.tcString}` which return whether GDPR applies to the session (broadly, is the browser in Europe) and the current consent string. Additionally `{tcf.gdprAppliesInt}` returns`{tcf.gdprApplies}` as an int, as this seems more commonly expected by ad servers. 

Updated docs, added tests. A demo page with a CMP is at https://consent.misterben.me/vjs.html