### PR TITLE
chore(nvmrc): Use erbium

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,2 +1,1 @@
-lts/*
-
+lts/erbium


### PR DESCRIPTION
Update .nvmrc to use node 12 to prevent compatibility issues with node 14.