### PR TITLE
test: ad unit test for multiple identical macros

### DIFF
--- a/test/integration/test.macros.js
+++ b/test/integration/test.macros.js
@@ -172,6 +172,17 @@ QUnit.test('pageVariables', function(assert) {
   );
 });
 
+QUnit.test('multiple, identical macros', function(assert) {
+  const result = this.player.ads.adMacroReplacement('...&documentrefferer1={document.referrer}&documentrefferer2={document.referrer}&windowlocation1={window.location.href}&windowlocation2={window.location.href}');
+  const expected = `...&documentrefferer1=${document.referrer}&documentrefferer2=${document.referrer}&windowlocation1=${window.location.href}&windowlocation2=${window.location.href}`;
+
+  assert.equal(
+    result,
+    expected,
+    `"${result}" includes 2 replaced document.referrer and 2 window.location.href strings`
+  );
+});
+
 QUnit.test('uriEncode', function(assert) {
   /* eslint-disable camelcase */
   this.player.mediainfo = {


### PR DESCRIPTION
New unit test for multiple, identical macro replacements in a string (for instance the serverUrl string). I.e.: `...&url={window.location.href}&description_url={window.location.href}...` using `ads.adMacroReplacement()`.