### PR TITLE
feat: Add `allowVjsAutoplay` option to add support for custom video.js autoplay settings

### DIFF
--- a/docs/integrator/options.md
+++ b/docs/integrator/options.md
@@ -59,7 +59,7 @@ Use this to override detection of if the content video is a live stream. Live de
 ### allowVjsAutoplay
 
 Type: `boolean`
-Default Value: `videojs.options.normalizeAutoplay` || false
+Default Value: `videojs.options.normalizeAutoplay || false`
 
 Set this to `true` if you intend to use video.js's custom autoplay settings ("play", "muted", or "any"). It defaults to `true` if the videojs `normalizeAutoplay` option is `true` since `normalizeAutoplay` signals an intent to use `autoplay: "play"` behavior.
 

--- a/docs/integrator/options.md
+++ b/docs/integrator/options.md
@@ -56,6 +56,13 @@ No Default Value
 
 Use this to override detection of if the content video is a live stream. Live detection checks if the duration is `Infinity` but there are cases when this check is insufficient.
 
+### allowVjsAutoplay
+
+Type: `boolean`
+Default Value: `false`
+
+Set this to `true` if you intend to use video.js's custom autoplay settings ("play", "muted", or "any").
+
 ### debug
 
 Type: `boolean`

--- a/docs/integrator/options.md
+++ b/docs/integrator/options.md
@@ -59,9 +59,9 @@ Use this to override detection of if the content video is a live stream. Live de
 ### allowVjsAutoplay
 
 Type: `boolean`
-Default Value: `false`
+Default Value: `videojs.options.normalizeAutoplay` || false
 
-Set this to `true` if you intend to use video.js's custom autoplay settings ("play", "muted", or "any").
+Set this to `true` if you intend to use video.js's custom autoplay settings ("play", "muted", or "any"). It defaults to `true` if the videojs `normalizeAutoplay` option is `true` since `normalizeAutoplay` signals an intent to use `autoplay: "play"` behavior.
 
 ### debug
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -72,7 +72,7 @@ const defaults = {
   // BeforePreroll if the player intends to autoplay. This allows the manual autoplay
   // attempt made by video.js to resolve/reject naturally and trigger an 'autoplay-success'
   // or 'autoplay-failure' event with which other plugins can interface.
-  allowVjsAutoplay: false
+  allowVjsAutoplay: videojs.options.normalizeAutoplay || false
 };
 
 const contribAdsPlugin = function(options) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -66,7 +66,13 @@ const defaults = {
   // If set to true, content will play muted behind ads on supported platforms. This is
   // to support ads on video metadata cuepoints during a live stream. It also results in
   // more precise resumes after ads during a live stream.
-  liveCuePoints: true
+  liveCuePoints: true,
+
+  // If set to true, callPlay middleware will not terminate the first play request in
+  // BeforePreroll if the player intends to autoplay. This allows the manual autoplay
+  // attempt made by video.js to resolve/reject naturally and trigger an 'autoplay-success'
+  // or 'autoplay-failure' event with which other plugins can interface.
+  allowVjsAutoplay: false
 };
 
 const contribAdsPlugin = function(options) {

--- a/src/states/BeforePreroll.js
+++ b/src/states/BeforePreroll.js
@@ -25,8 +25,8 @@ class BeforePreroll extends ContentState {
     this.adsReady = false;
     this.shouldResumeToContent = false;
 
-    // Content playback should be blocked until we are done
-    // playing ads or we know there are no ads to play
+    // Content playback should be blocked by callPlay() middleware if the allowVjsAutoplay
+    // option hasn't been provided and autoplay is not desired.
     player.ads._shouldBlockPlay = player.ads.settings.allowVjsAutoplay ? !player.autoplay() : true;
   }
 

--- a/src/states/BeforePreroll.js
+++ b/src/states/BeforePreroll.js
@@ -27,7 +27,7 @@ class BeforePreroll extends ContentState {
 
     // Content playback should be blocked until we are done
     // playing ads or we know there are no ads to play
-    player.ads._shouldBlockPlay = true;
+    player.ads._shouldBlockPlay = player.ads.settings.allowVjsAutoplay ? !player.autoplay() : true;
   }
 
   /*

--- a/test/unit/states/test.BeforePreroll.js
+++ b/test/unit/states/test.BeforePreroll.js
@@ -15,7 +15,8 @@ QUnit.module('BeforePreroll', {
     this.player = {
       ads: {
         debug: () => {},
-        _shouldBlockPlay: false
+        _shouldBlockPlay: false,
+        settings: {}
       },
       setTimeout: () => {},
       trigger: (event) => {
@@ -103,9 +104,27 @@ QUnit.test('handles content change', function(assert) {
   assert.equal(this.beforePreroll.init.calledOnce, true);
 });
 
-QUnit.test('sets _shouldBlockPlay to true', function(assert) {
+QUnit.test('sets _shouldBlockPlay to true by default', function(assert) {
   this.beforePreroll.init(this.player);
   assert.equal(this.player.ads._shouldBlockPlay, true);
+});
+
+QUnit.test('sets _shouldBlockPlay to true if allowVjsAutoplay option is true and player.autoplay() is false', function(assert) {
+  this.player.ads.settings.allowVjsAutoplay = true;
+
+  this.player.autoplay = () => false;
+
+  this.beforePreroll.init(this.player);
+  assert.equal(this.player.ads._shouldBlockPlay, true);
+});
+
+QUnit.test('sets _shouldBlockPlay to false if allowVjsAutoplay option is true and player.autoplay() is truthy', function(assert) {
+  this.player.ads.settings.allowVjsAutoplay = true;
+
+  this.player.autoplay = () => 'play';
+
+  this.beforePreroll.init(this.player);
+  assert.equal(this.player.ads._shouldBlockPlay, false);
 });
 
 QUnit.test('updates `shouldResumeToContent` on `nopreroll`', function(assert) {


### PR DESCRIPTION
## Description
Video.js recently added new functionality for autoplay that triggers `autoplay-success` or `autoplay-failure` events depending on the result of the autoplay attempt. However, that functionality relies on the initial play promise being resolved/rejected naturally, so it is not compatible with the contrib-ads `callPlay()` middleware which terminates the first play request.

This PR adds an option to bypass that play termination if the player intends to autoplay. It does this by conditionally setting `_shouldBlockPlay` to `false` in the `BeforePreroll` state if the option is `true` and `player.autoplay()` is truthy.