### PR TITLE
feat: Macro improvements

### DIFF
--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -24,26 +24,30 @@ adMacroReplacement takes 3 arguments:
 
 ## Static Macros
 
-| Name                     | Value                             |
-|:-------------------------|:----------------------------------|
-| {player.id}              | The player ID                     |
-| {player.width}           | The current player width          |
-| {player.height}          | The current player height         |
-| {player.duration}        | The duration of current video *   |
-| {player.pageUrl}         | The page URL ** ***               |
-| {timestamp}              | Current epoch time                |
-| {document.referrer}      | Value of document.referrer ***    |
-| {window.location.href}   | Value of window.location.href     |
-| {random}                 | A random number 0-1 trillion      |
-| {mediainfo.id}           | Pulled from mediainfo object      |
-| {mediainfo.name}         | Pulled from mediainfo object      |
-| {mediainfo.description}  | Pulled from mediainfo object      |
-| {mediainfo.tags}         | Pulled from mediainfo object      |
-| {mediainfo.reference_id} | Pulled from mediainfo object      |
-| {mediainfo.duration}     | Pulled from mediainfo object      |
-| {mediainfo.ad_keys}      | Pulled from mediainfo object      |
-| {playlistinfo.id}        | Pulled from playlistinfo object   |
-| {playlistinfo.name}      | Pulled from playlistinfo object   |
+| Name                     | Value                                 |
+|:-------------------------|:--------------------------------------|
+| {player.id}              | The player ID                         |
+| {player.width}           | The current player width              |
+| {player.height}          | The current player height             |
+| {player.widthInt}        | The current player width as int       |
+| {player.heightInt}       | The current player height as int      |
+| {player.duration}        | The duration of current video *       |
+| {player.durationInt}     | The duration as int *                  |
+| {player.pageUrl}         | The page URL ** ***                   |
+| {timestamp}              | Current epoch time                    |
+| {document.referrer}      | Value of document.referrer ***        |
+| {window.location.href}   | Value of window.location.href         |
+| {random}                 | A random number 0-1 trillion          |
+| {mediainfo.id}           | Pulled from mediainfo object          |
+| {mediainfo.name}         | Pulled from mediainfo object          |
+| {mediainfo.description}  | Pulled from mediainfo object          |
+| {mediainfo.tags}         | Pulled from mediainfo object          |
+| {mediainfo.reference_id} | Pulled from mediainfo object          |
+| {mediainfo.duration}     | Duration from mediainfo object        |
+| {mediainfo.durationInt}  | Duration from mediainfo object as int |
+| {mediainfo.ad_keys}      | Pulled from mediainfo object          |
+| {playlistinfo.id}        | Pulled from playlistinfo object       |
+| {playlistinfo.name}      | Pulled from playlistinfo object       |
 
 \* Returns 0 if video is not loaded. Be careful timing your ad request with this macro.
 
@@ -83,7 +87,7 @@ If the player is in an iframe, a proxy will be added if any parent frame is dete
 
 ## Default values in macros
 
-A default value can be provided within a macro, in which case this value will be used where not resolvable e.g. `http://example.com/ad/{pageVariable.adConf=1234}` becomes `http://example.com/ad/1234` if `window.adConf` is undefined.
+A default value can be provided within a macro in the format `{MACRO=DEFAULT}`, in which case this value will be used where not resolvable e.g. `http://example.com/ad/{pageVariable.adConf=1234}` becomes `http://example.com/ad/1234` if `window.adConf` is undefined. If a blank default is given, there will be a blank param, `http://example.com/ad?config={pageVariable.adConf=}&a=b` becomes `http://example.com/ad?config=&a=b` if `window.adConf` is unset.
 
 [tcf]: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
 [tcdata]: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#tcdata

--- a/src/macros.js
+++ b/src/macros.js
@@ -45,7 +45,7 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
   const defaults = {};
 
   // Get macros with defaults e.g. {x=y}, store values and replace with standard macros
-  string = string.replace(/{([^}=]+)=([^}]+)}/g, function(match, name, defaultVal) {
+  string = string.replace(/{([^}=]+)=([^}]*)}/g, function(match, name, defaultVal) {
     defaults[`{${name}}`] = defaultVal;
 
     return `{${name}}`;
@@ -65,10 +65,13 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
   macros['{player.id}'] = this.options_['data-player'] || this.id_;
   macros['{player.height}'] = this.currentHeight();
   macros['{player.width}'] = this.currentWidth();
+  macros['{player.heightInt}'] = Math.round(this.currentHeight());
+  macros['{player.widthInt}'] = Math.round(this.currentWidth());
   macros['{mediainfo.id}'] = this.mediainfo ? this.mediainfo.id : '';
   macros['{mediainfo.name}'] = this.mediainfo ? this.mediainfo.name : '';
   macros['{mediainfo.duration}'] = this.mediainfo ? this.mediainfo.duration : '';
   macros['{player.duration}'] = this.duration();
+  macros['{player.durationInt}'] = Math.round(this.duration());
   macros['{player.pageUrl}'] = videojs.dom.isInFrame() ? document.referrer : window.location.href;
   macros['{playlistinfo.id}'] = this.playlistinfo ? this.playlistinfo.id : '';
   macros['{playlistinfo.name}'] = this.playlistinfo ? this.playlistinfo.name : '';

--- a/test/integration/test.macros.js
+++ b/test/integration/test.macros.js
@@ -23,6 +23,17 @@ QUnit.test('player dimensions', function(assert) {
   assert.equal(resultWidth, 200, 'player.width was replaced');
 });
 
+QUnit.test('player dimensions as ints', function(assert) {
+  this.player.options_['data-player'] = '12345';
+  this.player.dimensions(200.3, 100.7);
+
+  const resultHeight = this.player.ads.adMacroReplacement('{player.heightInt}');
+  const resultWidth = this.player.ads.adMacroReplacement('{player.widthInt}');
+
+  assert.equal(resultHeight, 101, 'player.height was replaced with int');
+  assert.equal(resultWidth, 200, 'player.width was replaced with int');
+});
+
 QUnit.test('mediainfo', function(assert) {
   /* eslint-disable camelcase */
   this.player.mediainfo = {
@@ -64,6 +75,15 @@ QUnit.test('player.duration', function(assert) {
   const result = this.player.ads.adMacroReplacement('{player.duration}');
 
   assert.equal(result, 5);
+});
+
+QUnit.test('player.durationInt', function(assert) {
+  this.player.duration = function() {
+    return 5.2;
+  };
+  const result = this.player.ads.adMacroReplacement('{player.durationInt}');
+
+  assert.equal(result, 5, 'float diration returns as int');
 });
 
 QUnit.test('player.pageUrl', function(assert) {
@@ -250,6 +270,11 @@ QUnit.test('default values', function(assert) {
   assert.equal(
     this.player.ads.adMacroReplacement('{pageVariable.testvar2=c}'), 'c',
     'pageVariable: unset value is replaced by default'
+  );
+
+  assert.equal(
+    this.player.ads.adMacroReplacement('{pageVariable.testvar3=}'), '',
+    'pageVariable: unset value is replaced by default empty string'
   );
 });
 


### PR DESCRIPTION
1. Allows an empty string to be default value for a macro, eg. `{pageVariable.mightBeThere=}`
2. Adds versions of the duration and player size macros which always return an int

* `{player.widthInt}`
* `{player.heightInt}`
* `{player.durationInt}`
* `{mediainfo.durationInt}`