### PR TITLE
fix: Don't break on nested macros with undefined parent

### DIFF
--- a/src/macros.js
+++ b/src/macros.js
@@ -118,6 +118,9 @@ export default function adMacroReplacement(string, uriEncode, customMacros) {
         value = context[names[i]];
       } else {
         context = context[names[i]];
+        if (typeof context === 'undefined') {
+          break;
+        }
       }
     }
 

--- a/test/integration/test.macros.js
+++ b/test/integration/test.macros.js
@@ -156,7 +156,8 @@ QUnit.test('pageVariables', function(assert) {
     'Object: {pageVariable.bar}, ' +
     'Nested 2x: {pageVariable.animal.dog}, ' +
     'Nested 3x: {pageVariable.animal.cat.maineCoon}, ' +
-    'Nested 4x: {pageVariable.animal.cat.champion.name}');
+    'Nested 4x: {pageVariable.animal.cat.champion.name}, ' +
+    'Nested missing parent: {pageVariable.animal.ape.human}');
 
   assert.equal(
     result,
@@ -168,7 +169,8 @@ QUnit.test('pageVariables', function(assert) {
     'Object: , ' +
     'Nested 2x: Old Buddy, ' +
     'Nested 3x: Huge the Cat, ' +
-    'Nested 4x: Champ'
+    'Nested 4x: Champ, ' +
+    'Nested missing parent: '
   );
 });
 


### PR DESCRIPTION
Currently, a macro like `{pageVariable.foo.bar}` will cause an error if `foo` is not defined, as there's an attempt to access `foo.bar`.

Adds a check for whether each level is defined within the pageVariable string replacement.