### PR TITLE
Prevent disabled metadata TextTrack when create snapshot

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -262,7 +262,7 @@ const contribAdsPlugin = function(options) {
       for (let i = 0; i < textTrackList.length; i++) {
         const track = textTrackList[i];
 
-        if (track.mode === 'showing') {
+        if (track.mode === 'showing' && track.kind !== 'metadata') {
           track.mode = 'disabled';
         }
       }

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -51,7 +51,10 @@ export function getPlayerSnapshot(player) {
       track,
       mode: track.mode
     });
-    track.mode = 'disabled';
+
+    if (track.kind !== 'metadata') {
+      track.mode = 'disabled';
+    }
   }
   snapshotObject.suppressedTracks = suppressedTracks;
 


### PR DESCRIPTION
### Current behavior and problem

Before play ads that trigger by Cue Text Tracks the plugin create a player's snapshot in this process plugin store TextTrack in suppressedTracks array then set track mode to disabled to prevent TextTrack (subtitles?) to display on player when ads is playing after ads end the plugin restore player's snapshot and set TextTrack's mode back to original (before play ads)

After set TextTrack's mode back to original the browser see that TextTrack change from inactive to active it will trigger a `cuechange` event 

The integration received `cuechange` event then it try to play ads and repeat the whole snapshot process again forever you can see this behavior in example link below

[example](http://byteark-dev-player.st-th-1.byteark.com/videojs-contrib-ads/current/index.html)

### Solution

In this PR will not set metadata TextTrack mode to disabled  since metadata TextTrack is not visible on player and it will prevent browser to forever trigger `cuechange` event 

it's fixed the problem that I've mention above
[example](http://byteark-dev-player.st-th-1.byteark.com/videojs-contrib-ads/fix/index.html)