### PR TITLE
feat: Add support for US Privacy macro for CCPA compliance

### DIFF
--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -85,9 +85,9 @@ A macro such as {pageVariable.foobar} allows the user access the value of any pr
 | Undefined | Logs warning and returns empty string |
 | Other     | Logs warning and returns empty string |
 
-### Consent Macros
+## Consent Macros
 
-## TCF macros
+### TCF macros
 
 If a CMP supporting the [GDPR Transparency and Consent Framework][tcf] is in use additional tcf macros are made available. The syntax is `{tcf.*}`, with `*` being a property in the [tcData][tcdata] object. Most commonly used will be:
 
@@ -100,7 +100,7 @@ Since `gdprApplies` is a boolean and many ad servers expect the value as an int,
 
 If the player is in an iframe, a proxy will be added if any parent frame is detected to gain consent with the postmessage API. The CMP must be loaded first.
 
-## US Privacy macros
+### US Privacy macros
 
 Similar to TCF, if a CMP supporting the [US Privacy API][usp] is in use, additional macros related to US Privacy are made available. At this time, one macro is supported.
 

--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -85,7 +85,9 @@ A macro such as {pageVariable.foobar} allows the user access the value of any pr
 | Undefined | Logs warning and returns empty string |
 | Other     | Logs warning and returns empty string |
 
-### TCF macros
+### Consent Macros
+
+## TCF macros
 
 If a CMP supporting the [GDPR Transparency and Consent Framework][tcf] is in use additional tcf macros are made available. The syntax is `{tcf.*}`, with `*` being a property in the [tcData][tcdata] object. Most commonly used will be:
 
@@ -97,6 +99,22 @@ If a CMP supporting the [GDPR Transparency and Consent Framework][tcf] is in use
 Since `gdprApplies` is a boolean and many ad servers expect the value as an int, an additional `{tcf.gdprAppliesInt}` is provided which will return `1` or `0`.
 
 If the player is in an iframe, a proxy will be added if any parent frame is detected to gain consent with the postmessage API. The CMP must be loaded first.
+
+## US Privacy macros
+
+Similar to TCF, if a CMP supporting the [US Privacy API][usp] is in use additional macros related to US Privacy are made available. At this time, only one macro is supported.
+
+| Name                     | Value                                       |
+|:-------------------------|:--------------------------------------------|
+| {usp.uspString}          | The US Privacy consent string, ex. '1YNN'   |
+
+The USP API works a bit differently than TCF. In order to ensure that the `adMacroReplacement()` call replaces the macro with the most up-to-date consent string, it is recommended that the integrator first call `player.ads.updateUsPrivacyString()`, which is asynchronous due to how the USP API works.
+
+```js
+player.ads.updateUsPrivacyString(() => {
+  player.ads.adMacroReplacement('http://example.com/vmap.xml?usp={usp.uspString}');
+});
+```
 
 ### Default values in macros
 
@@ -145,5 +163,6 @@ const replacedString = player.ads.adMacroReplacement(stringWithMacros, false, cu
 In this case, the `replacedString` would not replace the `{player.id}` macro but would replace the custom `{myVar}` macro.
 
 [tcf]: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
+[usp]: https://github.com/InteractiveAdvertisingBureau/USPrivacy
 [tcdata]: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#tcdata
 [referrer-policy]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -102,16 +102,17 @@ If the player is in an iframe, a proxy will be added if any parent frame is dete
 
 ## US Privacy macros
 
-Similar to TCF, if a CMP supporting the [US Privacy API][usp] is in use additional macros related to US Privacy are made available. At this time, only one macro is supported.
+Similar to TCF, if a CMP supporting the [US Privacy API][usp] is in use, additional macros related to US Privacy are made available. At this time, one macro is supported.
 
 | Name                     | Value                                       |
 |:-------------------------|:--------------------------------------------|
 | {usp.uspString}          | The US Privacy consent string, ex. '1YNN'   |
 
-The USP API works a bit differently than TCF. In order to ensure that the `adMacroReplacement()` call replaces the macro with the most up-to-date consent string, it is recommended that the integrator first call `player.ads.updateUsPrivacyString()`, which is asynchronous due to how the USP API works.
+The USP API works a bit differently than TCF. In order to ensure that `adMacroReplacement()` replaces the macro with the most up-to-date consent string, it is recommended that the integrator first call `player.ads.updateUsPrivacyString()`, which is asynchronous due to how the USP API works. This plugin will automatically update the consent string at the time of initialization, but any changes to the consent string after initialization will only be picked up by calling `player.ads.updateUsPrivacyString()` again.
 
 ```js
-player.ads.updateUsPrivacyString(() => {
+player.ads.updateUsPrivacyString((privacyString) => {
+  // This will now use the most current privacy string. You can also do something here with the `privacyString` directly.
   player.ads.adMacroReplacement('http://example.com/vmap.xml?usp={usp.uspString}');
 });
 ```

--- a/src/macros.js
+++ b/src/macros.js
@@ -8,7 +8,8 @@ import document from 'global/document';
 
 import videojs from 'video.js';
 
-import { tcData } from './tcf.js';
+import {tcData} from './tcf.js';
+import {getCurrentUspString} from './usPrivacy.js';
 
 const uriEncodeIfNeeded = function(value, uriEncode) {
   return uriEncode ? encodeURIComponent(value) : value;
@@ -110,6 +111,10 @@ const getTcfMacros = function(tcDataObj) {
   tcfMacros['{tcf.gdprAppliesInt}'] = tcDataObj.gdprApplies ? 1 : 0;
 
   return tcfMacros;
+};
+
+const getUspMacros = () => {
+  return {'{usp.uspString}': getCurrentUspString()};
 };
 
 const getPageVariableMacros = function(string, defaults) {
@@ -217,6 +222,7 @@ export default function adMacroReplacement(string, uriEncode = false, customMacr
     getStaticMacros(this),
     getMediaInfoMacros(this.mediainfo, defaults),
     getTcfMacros(tcData),
+    getUspMacros(),
     getPageVariableMacros(string, defaults)
   );
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -15,7 +15,8 @@ import cueTextTracks from './cueTextTracks.js';
 import initCancelContentPlay from './cancelContentPlay.js';
 import playMiddlewareFeature from './playMiddleware.js';
 import register from './register.js';
-import { listenToTcf } from './tcf.js';
+import {listenToTcf} from './tcf.js';
+import {obtainUsPrivacyString} from './usPrivacy.js';
 
 import States from './states.js';
 import './states/abstract/State.js';
@@ -294,9 +295,14 @@ const contribAdsPlugin = function(options) {
   // Listen to TCF changes
   listenToTcf();
 
+  // Initialize the US Privacy string
+  obtainUsPrivacyString(() => {});
+
   // Can be called for testing, or if the TCF CMP has loaded late
   player.ads.listenToTcf = listenToTcf;
 
+  // Expose so the US privacy string can be updated as needed
+  player.ads.updateUsPrivacyString = (callback) => obtainUsPrivacyString(callback);
 };
 
 // Expose the contrib-ads version before it is initialized. Will be replaced

--- a/src/usPrivacy.js
+++ b/src/usPrivacy.js
@@ -1,0 +1,68 @@
+import window from 'global/window';
+
+const findUspApiLocatorWindow = (windowObj) => {
+  let targetWindow = windowObj.parent;
+
+  while (targetWindow !== windowObj.top) {
+    if (targetWindow.frames && targetWindow.frames.__uspapiLocator) {
+      return targetWindow;
+    }
+
+    targetWindow = targetWindow.parent;
+  }
+
+  return windowObj.top;
+};
+
+let uspString = '';
+
+export const getCurrentUspString = () => uspString;
+
+// Call the USP API to get the US Privacy String, either by invoking it directly or via postMessage() if inside an iframe.
+// In the former case the callback is synchronous, if the latter it is asynchronous, so to be safe it should always be
+// assumed to be asynchronous.
+// The window is passable as an argument for ease of testing
+export const obtainUsPrivacyString = (callback, windowObj = window) => {
+  if (windowObj.__uspapi) {
+    windowObj.__uspapi('getUSPData', 1, (uspData, success) => {
+      const privacyString = success ? uspData.uspString : null;
+
+      uspString = privacyString;
+
+      callback(privacyString);
+    });
+  } else {
+    const uniqueId = Math.random().toString(36).substring(2);
+    const message = {
+      __uspapiCall: {
+        command: 'getUSPData',
+        version: 1,
+        callId: uniqueId
+      }
+    };
+
+    const handleMessageEvent = (event) => {
+      if (
+        event &&
+        event.data &&
+        event.data.__uspapiReturn &&
+        event.data.__uspapiReturn.callId === uniqueId
+      ) {
+        windowObj.removeEventListener('message', handleMessageEvent, false);
+
+        const {returnValue, success} = event.data.__uspapiReturn;
+        const privacyString = success ? returnValue.uspString : null;
+
+        uspString = privacyString;
+
+        callback(privacyString);
+      }
+    };
+
+    windowObj.addEventListener('message', handleMessageEvent, false);
+
+    const targetWindow = findUspApiLocatorWindow(windowObj);
+
+    targetWindow.postMessage(message, '*');
+  }
+};

--- a/test/integration/test.macros.js
+++ b/test/integration/test.macros.js
@@ -404,6 +404,44 @@ QUnit.test('tcfMacros', function(assert) {
   window.__tcfapi = oldtcf;
 });
 
+QUnit.test('US Privacy macros', function(assert) {
+  const done = assert.async();
+  const olduspapi = window.__uspapi;
+
+  window.__uspapi = function(cmd, version, cb) {
+    if (cmd === 'getUSPData') {
+      cb({uspString: '1YNN'}, true);
+    }
+  };
+
+  this.player.ads.updateUsPrivacyString(() => {
+    assert.equal(
+      this.player.ads.adMacroReplacement('usp={usp.uspString}'),
+      'usp=1YNN',
+      'us privacy macro replaced correctly'
+    );
+
+    // Update the __uspapi function to return a new uspString
+    window.__uspapi = function(cmd, version, cb) {
+      if (cmd === 'getUSPData') {
+        cb({uspString: '1YNY'}, true);
+      }
+    };
+
+    // Call updateUsPrivacyString() again to update the uspString
+    this.player.ads.updateUsPrivacyString(() => {
+      assert.equal(
+        this.player.ads.adMacroReplacement('usp={usp.uspString}'),
+        'usp=1YNY',
+        'us privacy macro replaced correctly after updating the uspString'
+      );
+
+      window.__uspapi = olduspapi;
+      done();
+    });
+  });
+});
+
 QUnit.test('default macros should not be replaced when disableDefaultMacros is true', function(assert) {
   const string = '{player.id}';
   const customMacros = {

--- a/test/unit/test.usPrivacy.js
+++ b/test/unit/test.usPrivacy.js
@@ -1,0 +1,166 @@
+import QUnit from 'qunit';
+import {obtainUsPrivacyString, getCurrentUspString} from '../../src/usPrivacy.js';
+import sinon from 'sinon';
+
+QUnit.module('US Privacy - obtainUsPrivacyString()', () => {
+
+  QUnit.test('should call callback with uspString when __uspapi is available', (assert) => {
+    const done = assert.async();
+    const uspData = {uspString: '1YNN'};
+
+    const customWindow = {
+      __uspapi: (command, version, cb) => {
+        cb(uspData, true);
+      }
+    };
+
+    obtainUsPrivacyString((result) => {
+      assert.equal(result, uspData.uspString, 'uspString is returned');
+      done();
+    }, customWindow);
+  });
+
+  QUnit.test('should call callback with null when __uspapi is available but call is unsuccessful', (assert) => {
+    const done = assert.async();
+
+    const customWindow = {
+      __uspapi: (command, version, cb) => {
+        cb(null, false);
+      }
+    };
+
+    obtainUsPrivacyString((result) => {
+      assert.equal(result, null, 'null is returned');
+      done();
+    }, customWindow);
+  });
+
+  QUnit.test('should call callback with uspString when __uspapi is not available and received message is valid', (assert) => {
+    const done = assert.async();
+    const uspData = {uspString: '1YNN'};
+    const uniqueId = 'testUniqueId'.toString(36).substring(2);
+
+    const successfulMessageEvent = {
+      data: {
+        __uspapiReturn: {
+          callId: uniqueId,
+          returnValue: uspData,
+          success: true
+        }
+      }
+    };
+
+    const eventListeners = {};
+
+    const customWindow = {
+      addEventListener: (event, handler) => {
+        eventListeners[event] = handler;
+      },
+      removeEventListener: (event) => {
+        delete eventListeners[event];
+      }
+    };
+
+    customWindow.parent = {
+      frames: {
+        __uspapiLocator: true
+      },
+      postMessage: () => {
+        setTimeout(() => {
+          eventListeners.message(successfulMessageEvent);
+        }, 0);
+      }
+    };
+
+    customWindow.top = customWindow.parent;
+
+    sinon.stub(Math, 'random').returns('testUniqueId');
+
+    obtainUsPrivacyString((result) => {
+      assert.equal(result, uspData.uspString, 'uspString is returned');
+      Math.random.restore();
+      done();
+    }, customWindow);
+  });
+
+  QUnit.test('should call callback with uspString when __uspapi is not available and received message is not valid', (assert) => {
+    const done = assert.async();
+    const uniqueId = 'testUniqueId'.toString(36).substring(2);
+
+    const unsuccessfulMessageEvent = {
+      data: {
+        __uspapiReturn: {
+          callId: uniqueId,
+          returnValue: {},
+          success: false
+        }
+      }
+    };
+
+    const eventListeners = {};
+
+    const customWindow = {
+      addEventListener: (event, handler) => {
+        eventListeners[event] = handler;
+      },
+      removeEventListener: (event) => {
+        delete eventListeners[event];
+      }
+    };
+
+    customWindow.parent = {
+      frames: {
+        __uspapiLocator: true
+      },
+      postMessage: () => {
+        setTimeout(() => {
+          eventListeners.message(unsuccessfulMessageEvent);
+        }, 0);
+      }
+    };
+
+    customWindow.top = customWindow.parent;
+
+    sinon.stub(Math, 'random').returns('testUniqueId');
+
+    obtainUsPrivacyString((result) => {
+      assert.equal(result, null, 'null is returned');
+      Math.random.restore();
+      done();
+    }, customWindow);
+  });
+});
+
+QUnit.module('US Privacy - getCurrentUspString()', () => {
+
+  QUnit.test('should return the latest uspString', (assert) => {
+    const done1 = assert.async();
+    const done2 = assert.async();
+    const uspData1 = {uspString: '1YNN'};
+    const uspData2 = {uspString: '1YNY'};
+
+    const customWindow1 = {
+      __uspapi: (command, version, cb) => {
+        cb(uspData1, true);
+      }
+    };
+
+    const customWindow2 = {
+      __uspapi: (command, version, cb) => {
+        cb(uspData2, true);
+      }
+    };
+
+    obtainUsPrivacyString((result1) => {
+      assert.equal(result1, uspData1.uspString, 'uspString1 is returned');
+      assert.equal(getCurrentUspString(), uspData1.uspString, 'getCurrentUspString() returns the latest uspString1');
+      done1();
+    }, customWindow1);
+
+    obtainUsPrivacyString((result2) => {
+      assert.equal(result2, uspData2.uspString, 'uspString2 is returned');
+      assert.equal(getCurrentUspString(), uspData2.uspString, 'getCurrentUspString() returns the latest uspString2');
+      done2();
+    }, customWindow2);
+  });
+});


### PR DESCRIPTION
## Description
This PR adds support for a `{usp.uspString}` macro that is replaced with the US Privacy consent string, which is acquired using the IAB's [USP API](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/USP%20API.md) if it is available. The implementation follows the [reference code](https://github.com/InteractiveAdvertisingBureau/CCPA-reference-code) from IAB--  the API is invoked directly if it is available in the same window as the player, or via `postMessage()` if in a parent window. This also follows the same basic pattern as our implementation of TCF in this plugin, with a key difference. TCF triggers an event whenever the consent string changes, which lets us easily keep the string updated. The USP API does not, and manual asynchronous API calls are necessary to update it.

#### Test pages with reference USP API implementation:
- [in-page](https://solutions.brightcove.com/abarstow/CCPA/index-ads.html)
- [iframe](https://solutions.brightcove.com/abarstow/CCPA/index-ads-iframe.html)

Open the pages and select different options from the "Do Not Sell My Data" menu.
