### PR TITLE
feat: Add support for regex macros

### DIFF
--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -98,7 +98,7 @@ Since `gdprApplies` is a boolean and many ad servers expect the value as an int,
 
 If the player is in an iframe, a proxy will be added if any parent frame is detected to gain consent with the postmessage API. The CMP must be loaded first.
 
-### Default values in macros
+### Default Values in Macros
 
 A default value can be provided within a macro in the format `{MACRO=DEFAULT}`, in which case this value will be used where not resolvable e.g. `http://example.com/ad/{pageVariable.adConf=1234}` becomes `http://example.com/ad/1234` if `window.adConf` is undefined. If a blank default is given, there will be a blank param, `http://example.com/ad?config={pageVariable.adConf=}&a=b` becomes `http://example.com/ad?config=&a=b` if `window.adConf` is unset.
 
@@ -143,6 +143,36 @@ const replacedString = player.ads.adMacroReplacement(stringWithMacros, false, cu
 ```
 
 In this case, the `replacedString` would not replace the `{player.id}` macro but would replace the custom `{myVar}` macro.
+
+## Regex Macros
+Regular expressions can be used to match complex patterns and replace them with either dynamic values or existing default macro values. One use case for this feature is to support tokens with ambiguous whitespace. For example, `{{url.foo}}` vs. `{{ url.foo }}`
+
+### Replacing Regex Macros with Custom Values
+To replace a regex macro with a custom value, pass a key-value pair in the `customMacros` parameter with key in the format `'r:<REGEX_PATTERN>'`. The value will be used as the replacement for any macros in the string that match the provided regex.
+
+```js
+const someValue = 'customValue';
+const stringWithMacros = "http://example.com/ad?foo={{ url.foo }}&foo2={{url.foo}}";
+
+const replacedString = player.ads.adMacroReplacement(stringWithMacros, false, {
+  'r:{{[\\s]*url.foo[\\s]*}}': someValue
+});
+```
+In this example, the `replacedString` will replace both the `{{url.foo}}` and `{{ url.foo }}` macro with the value of `someValue`.
+
+### Overriding Default Macro Names with Regex Macros
+You can also override a default macro name with a regex macro by passing a key-value pair to the `macroNameOverrides` property of the `customMacros` parameter with the key representing the default macro name and the value in the format `'r:<REGEX_PATTERN>'`. Any macros in the string that match the regex will be replaced with the value that would normally replace the provided default macro.
+
+```js
+const stringWithMacros = "http://example.com/ad?duration={{ url.foo }}";
+
+const replacedString = player.ads.adMacroReplacement(stringWithMacros, false, {
+  macroNameOverrides: {
+    '{player.duration}': 'r:{{[\\s]*url.foo[\\s]*}}'
+  }
+});
+```
+In this example, the `replacedString` will replace the `{{ url.foo }}` macro with the value that normally replaces the `{player.duration}` macro.
 
 [tcf]: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md
 [tcdata]: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#tcdata

--- a/src/macros.js
+++ b/src/macros.js
@@ -158,9 +158,20 @@ const getPageVariableMacros = function(string, defaults, macroNameOverrides) {
 
 const replaceMacros = function(string, macros, uriEncode, overrides = {}) {
   for (const macroName in macros) {
+    // The resolvedMacroName is the macro as it appears in the actual string
     const resolvedMacroName = overrides.hasOwnProperty(macroName) ? overrides[macroName] : macroName;
 
-    string = string.split(resolvedMacroName).join(uriEncodeIfNeeded(macros[macroName], uriEncode));
+    if (resolvedMacroName.startsWith('r:')) {
+      try {
+        const regex = new RegExp(resolvedMacroName.slice(2), 'g');
+
+        string = string.replace(regex, uriEncodeIfNeeded(macros[macroName], uriEncode));
+      } catch (error) {
+        videojs.log.warn('Unable to replace regex macro. Please verify that you are passing valid regex.');
+      }
+    } else {
+      string = string.split(resolvedMacroName).join(uriEncodeIfNeeded(macros[macroName], uriEncode));
+    }
   }
 
   return string;

--- a/src/macros.js
+++ b/src/macros.js
@@ -158,7 +158,7 @@ const getPageVariableMacros = function(string, defaults, macroNameOverrides) {
 
 const replaceMacros = function(string, macros, uriEncode, overrides = {}) {
   for (const macroName in macros) {
-    // The resolvedMacroName is the macro as it appears in the actual string
+    // The resolvedMacroName is the macro as it is expected to appear in the actual string, or regex if it has been provided.
     const resolvedMacroName = overrides.hasOwnProperty(macroName) ? overrides[macroName] : macroName;
 
     if (resolvedMacroName.startsWith('r:')) {
@@ -167,7 +167,7 @@ const replaceMacros = function(string, macros, uriEncode, overrides = {}) {
 
         string = string.replace(regex, uriEncodeIfNeeded(macros[macroName], uriEncode));
       } catch (error) {
-        videojs.log.warn('Unable to replace regex macro. Please verify that you are passing valid regex.');
+        videojs.log.warn(`Unable to replace macro with regex "${resolvedMacroName}". The provided regex may be invalid.`);
       }
     } else {
       string = string.split(resolvedMacroName).join(uriEncodeIfNeeded(macros[macroName], uriEncode));

--- a/test/integration/test.macros.js
+++ b/test/integration/test.macros.js
@@ -497,7 +497,6 @@ QUnit.test('mediainfo.custom_fields macros can be overridden', function(assert) 
   const result = this.player.ads.adMacroReplacement(string, false, customMacros);
 
   assert.strictEqual(result, 'testValue', 'mediainfo.custom_fields macros should be overridden correctly');
-  delete this.mediainfo;
 });
 
 QUnit.test('TCF macro names can be overridden', function(assert) {
@@ -554,5 +553,5 @@ QUnit.test('disableDefaultMacros and macroNameOverrides customMacro properties s
 
   const result = this.player.ads.adMacroReplacement(string, false, customMacros);
 
-  assert.strictEqual(result, string, 'default macros should not be replaced');
+  assert.strictEqual(result, string, 'special customMacros properties should not be replaced');
 });

--- a/test/integration/test.macros.js
+++ b/test/integration/test.macros.js
@@ -558,9 +558,6 @@ QUnit.test('disableDefaultMacros and macroNameOverrides customMacro properties s
   assert.strictEqual(result, string, 'special customMacros properties should not be replaced');
 });
 
-// **********************************************************************************************************************************************
-// **********************************************************************************************************************************************
-
 QUnit.test('regex macro should be replaced when passed in customMacros', function(assert) {
   const string = 'Test: {{url.foo}}';
   const customMacros = {
@@ -590,14 +587,14 @@ QUnit.test('regex macro should override default macro', function(assert) {
 });
 
 QUnit.test('regex macro should replace multiple instances of the pattern', function(assert) {
-  const string = 'Test: {{url.foo}} and {{url.foo}}';
+  const string = 'Test: {{url.foo}} and {{url.foo}} and {{ url.foo }}';
   const customMacros = {
     'r:{{[\\s]*url.foo[\\s]*}}': 'someValue'
   };
 
   const result = this.player.ads.adMacroReplacement(string, false, customMacros);
 
-  assert.strictEqual(result, 'Test: someValue and someValue', 'regex macro should replace multiple instances of the pattern');
+  assert.strictEqual(result, 'Test: someValue and someValue and someValue', 'regex macro should replace multiple instances of the pattern');
 });
 
 QUnit.test('replaceMacros() should log a warning when invalid regex is passed', function(assert) {
@@ -614,6 +611,6 @@ QUnit.test('replaceMacros() should log a warning when invalid regex is passed', 
   const result = this.player.ads.adMacroReplacement(string, false, customMacros);
 
   assert.strictEqual(result, 'Test: somePlayerId - {{url.foo}}', 'regex macro should not be replaced, but others should be');
-  assert.ok(vjsWarnSpy.calledOnce, 'console.warn should be called once');
+  assert.ok(vjsWarnSpy.calledOnce, 'videojs.log.warn should be called once');
   vjsWarnSpy.restore();
 });


### PR DESCRIPTION
## Description
This PR does two things:
- Adds support for replacing multiple macros that match a regular expression (see full description in readme changes)
- Simplifies and fixes a design flaw in the macro name override logic, specifically for pageVariable macros