### PR TITLE
fix: updateUsPrivacyString() callback not invoked when USP API not in use in any window

### DIFF
--- a/docs/integrator/macros.md
+++ b/docs/integrator/macros.md
@@ -108,11 +108,12 @@ Similar to TCF, if a CMP supporting the [US Privacy API][usp] is in use, additio
 |:-------------------------|:--------------------------------------------|
 | {usp.uspString}          | The US Privacy consent string, ex. '1YNN'   |
 
-The USP API works a bit differently than TCF. In order to ensure that `adMacroReplacement()` replaces the macro with the most up-to-date consent string, it is recommended that the integrator first call `player.ads.updateUsPrivacyString()`, which is asynchronous due to how the USP API works. This plugin will automatically update the consent string at the time of initialization, but any changes to the consent string after initialization will only be picked up by calling `player.ads.updateUsPrivacyString()` again.
+The USP API works a bit differently than TCF. In order to ensure that `adMacroReplacement()` replaces the macro with the most up-to-date consent string, it is recommended that the integrator first call `player.ads.updateUsPrivacyString()`, which is asynchronous due to how the USP API works. This plugin will automatically update the consent string at the time of initialization, but any changes to the consent string after initialization will only be picked up by calling `player.ads.updateUsPrivacyString()` again, like this:
 
 ```js
 player.ads.updateUsPrivacyString((privacyString) => {
-  // This will now use the most current privacy string. You can also do something here with the `privacyString` directly.
+  // adMacroReplacement() will now use the most current privacy string. You can also do something here with the `privacyString` directly.
+  // The `privacyString` will be `null` if the USP API is unable to return any privacy information, or if the API is not present.
   player.ads.adMacroReplacement('http://example.com/vmap.xml?usp={usp.uspString}');
 });
 ```

--- a/src/usPrivacy.js
+++ b/src/usPrivacy.js
@@ -11,7 +11,13 @@ const findUspApiLocatorWindow = (windowObj) => {
     targetWindow = targetWindow.parent;
   }
 
-  return windowObj.top;
+  // Check for the __uspapiLocator frame in the top window
+  if (windowObj.top.frames && windowObj.top.frames.__uspapiLocator) {
+    return windowObj.top;
+  }
+
+  // Return null if no __uspapiLocator frame is found in any window
+  return null;
 };
 
 let uspString = '';
@@ -32,6 +38,14 @@ export const obtainUsPrivacyString = (callback, windowObj = window) => {
       callback(privacyString);
     });
   } else {
+    const targetWindow = findUspApiLocatorWindow(windowObj);
+
+    // If no __uspapiLocator frame is found, execute the callback with a null privacy string
+    if (!targetWindow) {
+      callback(null);
+      return;
+    }
+
     const uniqueId = Math.random().toString(36).substring(2);
     const message = {
       __uspapiCall: {
@@ -60,8 +74,6 @@ export const obtainUsPrivacyString = (callback, windowObj = window) => {
     };
 
     windowObj.addEventListener('message', handleMessageEvent, false);
-
-    const targetWindow = findUspApiLocatorWindow(windowObj);
 
     targetWindow.postMessage(message, '*');
   }

--- a/test/unit/test.usPrivacy.js
+++ b/test/unit/test.usPrivacy.js
@@ -131,6 +131,24 @@ QUnit.module('US Privacy - obtainUsPrivacyString()', () => {
   });
 });
 
+QUnit.test('should call callback with null when __uspapi and __uspapiLocator are not available in any window', (assert) => {
+  const done = assert.async();
+
+  const customWindow = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    postMessage: () => {}
+  };
+
+  customWindow.parent = customWindow;
+  customWindow.top = customWindow;
+
+  obtainUsPrivacyString((result) => {
+    assert.equal(result, null, 'null is returned when no __uspapi or __uspapiLocator are present');
+    done();
+  }, customWindow);
+});
+
 QUnit.module('US Privacy - getCurrentUspString()', () => {
 
   QUnit.test('should return the latest uspString', (assert) => {


### PR DESCRIPTION
## Description
`player.ads.updateUsPrivacyString(callback)` would not invoke the callback if the USP API was not present in the current window or any parent window. Now it is synchronously invoked with a `null` privacyString, so `updateUsPrivacyString()` can be used safely when the presence of the USP API is uncertain.