### PR TITLE
fix: suppress errors while looking for `__uspapiLocator`

### DIFF
--- a/src/usPrivacy.js
+++ b/src/usPrivacy.js
@@ -4,16 +4,24 @@ const findUspApiLocatorWindow = (windowObj) => {
   let targetWindow = windowObj.parent;
 
   while (targetWindow !== windowObj.top) {
-    if (targetWindow.frames && targetWindow.frames.__uspapiLocator) {
-      return targetWindow;
+    try {
+      if (targetWindow.frames && targetWindow.frames.__uspapiLocator) {
+        return targetWindow;
+      }
+    } catch (ignore) {
+      // do nothing
     }
 
     targetWindow = targetWindow.parent;
   }
 
   // Check for the __uspapiLocator frame in the top window
-  if (windowObj.top.frames && windowObj.top.frames.__uspapiLocator) {
-    return windowObj.top;
+  try {
+    if (windowObj.top.frames && windowObj.top.frames.__uspapiLocator) {
+      return windowObj.top;
+    }
+  } catch (ignore) {
+    // do nothing
   }
 
   // Return null if no __uspapiLocator frame is found in any window


### PR DESCRIPTION
Integrations where the video.js player is in an iframe with a different origin are throwing errors when `findUspApiLocatorWindow` attempts to locate an ancestor frame with `ancestor.frames.__uspapiLocator`. 

No error is thown: 
* if the ancestor is same origin and a `__uspapiLocator` frame does not exist
* if the ancestor is not same origin but a `__uspapiLocator` locator frame exists

To remedy, we can wrap attempts to read `ancestorFrame.__uspapiLocator` in a try / catch. There is no need to handle the error as 
a) we'd expect to run into this while traversing multiple cross domain ancestors and 
b) if we don't find one in the top window, it probably just means there's no CMP. Users can't control whether this runs or not, so a warning or error would just be clutter.