### PR TITLE
fix: Toggle autoplay directly on tech when restoring snapshot for iOS

### DIFF
--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -222,9 +222,12 @@ export function restorePlayerSnapshot(player, callback) {
     player.one('contentloadedmetadata', restoreTracks);
 
     // adding autoplay guarantees that Safari will load the content so we can
-    // seek back to the correct time after ads
-    if (videojs.browser.IS_IOS && !player.autoplay()) {
-      player.autoplay(true);
+    // seek back to the correct time after ads.
+    // This is done directly on the html5 tech because if the integration has set
+    // normalizeAutoplay to true, the async play request via autoplay -> manualAutoplay_
+    // causes a visible skipback of the content after the ad break
+    if (videojs.browser.IS_IOS && !player.autoplay() && typeof player.techCall_ === 'function') {
+      player.techCall_('setAutoplay', true);
 
       // if we get here, the player was not originally configured to autoplay,
       // so we should remove it after it has served its purpose

--- a/test/integration/test.snapshot.js
+++ b/test/integration/test.snapshot.js
@@ -527,3 +527,64 @@ QUnit.test('Call play after live preroll on iOS', function(assert) {
   this.player.trigger('contentcanplay');
   assert.strictEqual(played, 1, 'Play happened');
 });
+
+QUnit.test('sets autoplay directly on tech when forcing content load for iOS', function(assert) {
+
+  this.player.ads.videoElementRecycled = () => true;
+  videojs.browser = {IS_IOS: true};
+  this.player.play = () => {};
+
+  this.player.trigger('loadstart');
+  this.player.trigger('adsready');
+  this.player.trigger('play');
+
+  assert.notOk(this.player.tech("it's fine").autoplay(), 'confirm autoplay on tech is off initially');
+  assert.notOk(this.player.autoplay(), 'confirm autoplay for vjs is off initially');
+  this.player.ads.startLinearAdMode();
+  this.player.ads.endLinearAdMode();
+  this.player.el().querySelector = query => {
+    if (query === '.vjs-tech') {
+      return {seekable: {length: 1}};
+    }
+  };
+
+  assert.ok(this.player.tech("it's fine").autoplay(), 'autoplay should be true on tech');
+  assert.notOk(this.player.autoplay(), 'autoplay should not be true on VJS');
+
+  // this will cause resume() to run and reset autoplay status if required
+  this.player.trigger('contentcanplay');
+
+  assert.notOk(this.player.tech("it's fine").autoplay(), 'confirm autoplay on tech is set back to off');
+  assert.notOk(this.player.autoplay(), 'confirm autoplay for vjs is still off');
+});
+
+QUnit.test('doesn\'t interfere with normal autoplay when forcing content load for iOS', function(assert) {
+
+  this.player.autoplay(true);
+  this.player.ads.videoElementRecycled = () => true;
+  videojs.browser = {IS_IOS: true};
+  this.player.play = () => {};
+
+  this.player.trigger('loadstart');
+  this.player.trigger('adsready');
+  this.player.trigger('play');
+
+  assert.ok(this.player.tech("it's fine").autoplay(), 'confirm autoplay on tech is on');
+  assert.ok(this.player.autoplay(), 'confirm autoplay for vjs is on');
+  this.player.ads.startLinearAdMode();
+  this.player.ads.endLinearAdMode();
+  this.player.el().querySelector = query => {
+    if (query === '.vjs-tech') {
+      return {seekable: {length: 1}};
+    }
+  };
+
+  assert.ok(this.player.tech("it's fine").autoplay(), 'autoplay should be true on tech');
+  assert.ok(this.player.autoplay(), 'autoplay should be true on VJS');
+
+  // this will cause resume() to run and reset autoplay status if required
+  this.player.trigger('contentcanplay');
+
+  assert.ok(this.player.tech("it's fine").autoplay(), 'confirm autoplay on tech is stil on');
+  assert.ok(this.player.autoplay(), 'confirm autoplay for vjs is still on');
+});


### PR DESCRIPTION
Problem:  `restorePlayerSnapshot` uses `autoplay(true)` to force a content load in iOS Safari for correct placement of the playhead after an ad break. However if an integration has set `normalizeAutoplay: true` in the setup of `videojs`, `autoplay()` hands off to an async, programatic  play request with `manualAutoplay('play')`. The subsequent seek-back causes a visible restart of the content after ~1 second of playback. 

Solution: We can avoid the visual glitch by toggling autoplay directly on the HTML5 tech.  The existing followup mechanism to clear out the autoplay status continues to work as expected as `autoplay(false)` is passed to the tech anyway.   