### PR TITLE
fix: Ad loading spinner animation misalignment

### DIFF
--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -11,12 +11,6 @@ Styles for ad plugins.
   background-color: #ffe400;
 }
 
-// Show the videojs loading spinner during ad loading
-.vjs-ad-loading .vjs-loading-spinner {
-  display: block;
-  visibility: visible;
-}
-
 // Hide the captions button during ad playback
 .vjs-ad-playing .vjs-captions-button {
     display: none;
@@ -27,25 +21,33 @@ Styles for ad plugins.
     display: none;
 }
 
-/* Following is copied from https://github.com/videojs/video.js/blob/master/src/css/components/_loading.scss
- this is needed to animate the spinner when ads, specifically VPAIDs, are loading.
- Long term solution is to add show/hide methods to the loading spinner component and move to displaying it via the methods rather than CSS.
+/* 
+ The following copies and expands from videojs loading spinner rules
+ https://github.com/videojs/video.js/blob/master/src/css/components/_loading.scss
+
+ This is needed to show and animate the spinner when ads, specifically VPAIDs, are loading.
+
+ Though we can't easily hook into the loading spinner component's show/hide methods
+ due to .vjs-hidden behavior, the long term solution may be to create a shared sass @mixin
+ for common spinner element and descendent rules and include them here
 */
-.vjs-ad-loading .vjs-loading-spinner:before,
-.vjs-ad-loading .vjs-loading-spinner:after {
-  -webkit-animation: vjs-spinner-spin 1.1s cubic-bezier(0.6, 0.2, 0, 0.8) infinite, vjs-spinner-fade 1.1s linear infinite;
-  animation: vjs-spinner-spin 1.1s cubic-bezier(0.6, 0.2, 0, 0.8) infinite, vjs-spinner-fade 1.1s linear infinite;
-}
 
-.vjs-ad-loading .vjs-loading-spinner:before
-{
-  border-top-color: rgb(255,255,255);
-}
+// Show the videojs loading spinner during ad loading
+.vjs-ad-loading {
+  .vjs-loading-spinner {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    animation: vjs-spinner-show 0s linear 0.3s forwards;
 
-.vjs-ad-loading .vjs-loading-spinner:after {
-  border-top-color: rgb(255,255,255);
-  -webkit-animation-delay: 0.44s;
-  animation-delay: 0.44s;
+    &:before, &:after {
+      animation: vjs-spinner-spin 1.1s cubic-bezier(0.6, 0.2, 0, 0.8) infinite, vjs-spinner-fade 1.1s linear infinite;
+    }
+
+    &:after {
+      animation-delay: 0.44s;
+    }
+  }
 }
 
 /*


### PR DESCRIPTION
Update contrib-ads implementation of the loading spinner component style to accommodate changes in videojs v8.11.x that cause a misalignment of the spinner segment animation before ad playback:

<img width="162" alt="Screenshot 2024-02-20 at 2 11 56 PM" src="https://github.com/videojs/videojs-contrib-ads/assets/83311511/9651f1a1-1cc7-4288-827c-ff9eb8cabd1f">

The contrib-ads implementation of an ad-specific spinner requires inherited rules from videojs and also a number of lines that were identical to videojs but became out of sync with recent updates. The inconsistency caused a minor visual defect, specifically because contrib-ads used `display: block` to make the spinner appear.

Fix parameters:
1.  Update `.vjs-ad-loading .vjs-loading-spinner` style to include `display:flex` and expected justify/alignment rules to center the spinner segment pseudo-elements, to match changes from videojs.
2. Remove outdated css animation fallbacks to match videojs
3. Add `animation: vjs-spinner-show` rule to match videojs. This also includes built-in visibility 
4. Remove extranuous `border-top-color: rgb(255,255,255)`
5. Consolidate and nest scss
6. Update the comment for context

Notes:
- These changes are backwards compatible with videojs v8.x
- To test locally: 
  - render the basic-ad-plugin page
  - hit the play button
  - pause
  - run `videojs('examplePlayer').addClass('vjs-ad-loading')` in the console to make the spinner appear and animate

<img width="244" alt="Screenshot 2024-02-20 at 2 11 23 PM" src="https://github.com/videojs/videojs-contrib-ads/assets/83311511/8d22f52a-96e4-4af9-9650-38a9a6324300">
