### PR TITLE
chore: move ad errors from videojs

### DIFF
--- a/src/consts/errors.js
+++ b/src/consts/errors.js
@@ -1,0 +1,10 @@
+const Error = {
+  AdsBeforePrerollError: 'ads-before-preroll-error',
+  AdsPrerollError: 'ads-preroll-error',
+  AdsMidrollError: 'ads-midroll-error',
+  AdsPostrollError: 'ads-postroll-error',
+  AdsMacroReplacementFailed: 'ads-macro-replacement-failed',
+  AdsResumeContentFailed: 'ads-resume-content-failed'
+};
+
+export default Error;

--- a/src/macros.js
+++ b/src/macros.js
@@ -10,6 +10,7 @@ import videojs from 'video.js';
 
 import {tcData} from './tcf.js';
 import {getCurrentUspString} from './usPrivacy.js';
+import AdsError from './consts/errors.js';
 
 const uriEncodeIfNeeded = function(value, uriEncode) {
   return uriEncode ? encodeURIComponent(value) : value;
@@ -173,7 +174,7 @@ const replaceMacros = function(string, macros, uriEncode, overrides = {}, player
         string = string.replace(regex, uriEncodeIfNeeded(macros[macroName], uriEncode));
       } catch (error) {
         player.ads.error({
-          errorType: videojs.Error.AdsMacroReplacementFailed,
+          errorType: AdsError.AdsMacroReplacementFailed,
           macro: macroName,
           error
         });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -18,6 +18,7 @@ import register from './register.js';
 import {listenToTcf} from './tcf.js';
 import {obtainUsPrivacyString} from './usPrivacy.js';
 import {OUTSTREAM_VIDEO} from './constants.js';
+import AdsError from './consts/errors';
 
 import States from './states.js';
 import './states/abstract/State.js';
@@ -312,6 +313,9 @@ const contribAdsPlugin = function(options) {
   // Expose so the US privacy string can be updated as needed
   player.ads.updateUsPrivacyString = (callback) => obtainUsPrivacyString(callback);
 };
+
+// contrib-ads specific error const
+contribAdsPlugin.Error = AdsError;
 
 // Expose the contrib-ads version before it is initialized. Will be replaced
 // after initialization in ads.js

--- a/src/snapshot.js
+++ b/src/snapshot.js
@@ -4,6 +4,7 @@ restoring the player state after an ad.
 */
 
 import videojs from 'video.js';
+import AdsError from './consts/errors.js';
 
 let tryToResumeTimeout_;
 
@@ -197,7 +198,7 @@ export function restorePlayerSnapshot(player, callback) {
         resume();
       } catch (e) {
         player.ads.error({
-          errorType: videojs.Error.AdsResumeContentFailed,
+          errorType: AdsError.AdsResumeContentFailed,
           error: e
         });
 

--- a/src/states/BeforePreroll.js
+++ b/src/states/BeforePreroll.js
@@ -1,5 +1,5 @@
-import videojs from 'video.js';
 import States from '../states.js';
+import AdsError from '../consts/errors.js';
 
 const ContentState = States.getState('ContentState');
 
@@ -68,7 +68,7 @@ class BeforePreroll extends ContentState {
     this.player.ads.debug('adserror (BeforePreroll)');
 
     this.player.ads.error({
-      errorType: videojs.Error.BeforePrerollError
+      errorType: AdsError.AdsBeforePrerollError
     });
 
     this.shouldResumeToContent = true;

--- a/src/states/Midroll.js
+++ b/src/states/Midroll.js
@@ -1,6 +1,6 @@
-import videojs from 'video.js';
 import States from '../states.js';
 import adBreak from '../adBreak.js';
+import AdsError from '../consts/errors';
 
 const AdState = States.getState('AdState');
 
@@ -50,7 +50,7 @@ class Midroll extends AdState {
    */
   onAdsError(player) {
     player.ads.error({
-      errorType: videojs.Error.AdsMidrollError
+      errorType: AdsError.AdsMidrollError
     });
 
     // In the future, we may not want to do this automatically.

--- a/src/states/Postroll.js
+++ b/src/states/Postroll.js
@@ -1,6 +1,7 @@
 import videojs from 'video.js';
 import adBreak from '../adBreak.js';
 import States from '../states.js';
+import AdsError from '../consts/errors.js';
 
 const AdState = States.getState('AdState');
 
@@ -118,7 +119,7 @@ class Postroll extends AdState {
     player.ads.debug('Postroll abort (adserror)');
 
     player.ads.error({
-      errorType: videojs.Error.AdsPostrollError
+      errorType: AdsError.AdsPostrollError
     });
 
     // In the future, we may not want to do this automatically.

--- a/src/states/Preroll.js
+++ b/src/states/Preroll.js
@@ -2,6 +2,7 @@ import videojs from 'video.js';
 import adBreak from '../adBreak.js';
 
 import States from '../states.js';
+import AdsError from '../consts/errors.js';
 
 const AdState = States.getState('AdState');
 
@@ -136,7 +137,7 @@ class Preroll extends AdState {
     videojs.log('adserror (Preroll)');
 
     player.ads.error({
-      errorType: videojs.Error.AdsPrerollError
+      errorType: AdsError.AdsPrerollError
     });
 
     // In the future, we may not want to do this automatically.


### PR DESCRIPTION
Quick update to add errors to this plugin. They will be removed from the video.js repo.